### PR TITLE
Introduce navigation references

### DIFF
--- a/src/data/components/navigation/context/main/details.toml
+++ b/src/data/components/navigation/context/main/details.toml
@@ -1,0 +1,1 @@
+name = "Main Navigation"

--- a/src/data/components/navigation/context/main/main_navigation.toml
+++ b/src/data/components/navigation/context/main/main_navigation.toml
@@ -1,0 +1,40 @@
+templates = ["""
+<div class="pf-l-flex pf-u-align-items-center pf-u-mt-lg pf-u-px-2xl">
+  <div class="pf-l-flex pf-m-grow">
+    <div>
+      <img class="pf-c-brand" src="https://developers.redhat.com/themes/custom/rhdp/logo.svg" alt="Red Hat Developer logo" width="240px">
+    </div>
+  </div>
+  <div class="pf-l-flex">
+    <nav class="pf-c-nav rhd-c-nav" aria-label="Local">
+      <ul class="pf-c-nav__tertiary-list">
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link pf-m-current" aria-current="page">
+            Events
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Training
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Help
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Products
+          </a>
+        </li>
+        <li class="pf-c-nav__item pf-u-mr-0">
+          <a href="#" class="pf-u-display-inline-block pf-u-pt-md pf-u-pb-sm">
+            <i class="fas fa-search"></i>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+"""]

--- a/src/data/components/navigation/context/main/main_navigation_mobile.toml
+++ b/src/data/components/navigation/context/main/main_navigation_mobile.toml
@@ -1,0 +1,56 @@
+templates = ["""
+<div class="pf-l-flex pf-u-align-items-center pf-u-mt-lg pf-u-px-2xl" style="max-width: 768px;">
+  <div class="pf-l-flex">
+    <div>
+      <img class="pf-c-brand" src="https://developers.redhat.com/themes/custom/rhdp/logo.svg" alt="Red Hat Developer logo" width="240px">
+    </div>
+  </div>
+  <div class="pf-l-flex pf-m-grow">
+    <div class="pf-c-dropdown pf-m-align-left pf-m-align-right-on-sm rhd-c-nav-dropdown rhd-m-expanded pf-m-expanded">
+      <button class="pf-c-dropdown__toggle" id="dropdown-basic-example-expanded-button" aria-expanded="true">
+        <span class="pf-c-dropdown__toggle-text">
+          Menu
+        </span>
+        <i class="fas fa-bars pf-c-dropdown__toggle-icon" aria-hidden="true"></i>
+      </button>
+    </div>
+  </div>
+</div>
+""",
+"""
+<h1 class="pf-c-title pf-m-lg pf-u-my-md">Main Navigation - Mobile: Expanded</h1>
+<div class="pf-l-flex pf-u-align-items-center pf-u-mt-lg pf-u-px-2xl" style="max-width: 768px;">
+  <div style="float: right">
+    <div class="pf-c-dropdown pf-m-align-left pf-m-align-right-on-sm rhd-c-nav-dropdown rhd-m-expanded pf-m-expanded">
+      <button class="pf-c-dropdown__toggle" id="dropdown-basic-example-expanded-button" aria-expanded="true">
+        <span class="pf-c-dropdown__toggle-text">
+          Menu
+        </span>
+        <i class="fas fa-bars pf-c-dropdown__toggle-icon" aria-hidden="true"></i>
+      </button>
+      <ul class="pf-c-dropdown__menu pf-m-align-right" aria-labelledby="dropdown-navigation-menu" style="position: relative; top: -47px;">
+        <li class="pf-u-display-flex pf-u-justify-content-space-between pf-u-px-md">
+          <div>
+            <i class="fas fa-user"></i> Login
+          </div>
+          <div>
+            Close <i class="fal fa-times-circle"></i>
+          </div>
+        </li>
+        <li>
+          <div class="pf-c-input-group">
+            <input class="pf-c-form-control" type="search" id="textInput11" name="textInput11" aria-label="search input example">
+            <button class="pf-c-button pf-m-tertiary" type="button" aria-label="search button for search input">
+              <i class="fas fa-search" aria-hidden="true"></i>
+            </button>
+          </div>
+        </li>
+        <li><a href="#"><span>Events</span><span class="rhd-m-nav-description">Link to Red Hat Developer Events</span></a></li>
+        <li><a href="#"><span>Training</span><span class="rhd-m-nav-description">Link to Red Hat Developer Events</span></a></li>
+        <li><a href="#"><span>Help</span><span class="rhd-m-nav-description">Link to Red Hat Developer Events</span></a></li>
+        <li><a href="#"><span>Products</span><span class="rhd-m-nav-description">Link to Red Hat Developer Events</span></a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+"""]

--- a/src/data/components/navigation/context/topic/details.toml
+++ b/src/data/components/navigation/context/topic/details.toml
@@ -1,0 +1,1 @@
+name = "Topic Navigation"

--- a/src/data/components/navigation/context/topic/topic_navigation.toml
+++ b/src/data/components/navigation/context/topic/topic_navigation.toml
@@ -1,0 +1,72 @@
+templates = ["""
+<div class="pf-l-flex pf-u-align-items-center pf-u-mt-lg pf-u-mx-2xl rhd-l-topics">
+  <div class="pf-l-flex pf-m-grow">
+    <nav class="pf-c-nav rhd-c-nav--topics" aria-label="Local">
+      <button class="pf-c-nav__scroll-button" aria-label="Scroll left">
+        <i class="fas fa-angle-left" aria-hidden="true"></i>
+      </button>
+      <ul class="pf-c-nav__tertiary-list">
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link pf-m-current" aria-current="page">
+            Istio
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Kubernetes
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Microservices
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            DevOps
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Serverless
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Linux
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Java
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Knative
+          </a>
+        </li>
+        <li class="pf-c-nav__item pf-u-mr-0 pf-u-display-flex pf-u-display-none-on-md">
+          <a href="#" class="pf-c-nav__link">
+            All topics <i class="fas fa-arrow-right"></i>
+          </a>
+        </li>
+      </ul>
+      <button class="pf-c-nav__scroll-button" aria-label="Scroll right">
+        <i class="fas fa-angle-right" aria-hidden="true"></i>
+      </button>
+    </nav>
+  </div>
+  <div class="pf-l-flex pf-u-display-none pf-u-display-flex-on-md">
+    <nav class="pf-c-nav rhd-c-nav--topics" aria-label="Local">
+      <ul class="pf-c-nav__tertiary-list">
+        <li class="pf-c-nav__item pf-u-mr-0">
+          <a href="#" class="pf-c-nav__link">
+            All topics <i class="fas fa-arrow-right"></i>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+"""]

--- a/src/data/components/navigation/context/topic/topic_navigation_mobile.toml
+++ b/src/data/components/navigation/context/topic/topic_navigation_mobile.toml
@@ -1,0 +1,61 @@
+templates = ["""
+<div class="pf-l-flex pf-u-align-items-center pf-u-mt-lg pf-u-mx-2xl">
+  <div class="pf-l-flex pf-m-grow">
+    <nav class="pf-c-nav pf-m-start pf-m-end rhd-c-nav--topics rhd-l-topics" aria-label="Local" style="max-width: 768px;">
+      <button class="pf-c-nav__scroll-button" aria-label="Scroll left">
+        <i class="fas fa-angle-left" aria-hidden="true"></i>
+      </button>
+      <ul class="pf-c-nav__tertiary-list">
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Istio
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Kubernetes
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Microservices
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            DevOps
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Serverless
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Linux
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Java
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="#" class="pf-c-nav__link">
+            Knative
+          </a>
+        </li>
+        <li class="pf-c-nav__item pf-u-mr-0">
+          <a href="#" class="pf-c-nav__link">
+            All topics <i class="fas fa-arrow-right"></i>
+          </a>
+        </li>
+      </ul>
+      <button class="pf-c-nav__scroll-button" aria-label="Scroll right">
+        <i class="fas fa-angle-right" aria-hidden="true"></i>
+      </button>
+    </nav>
+  </div>
+</div>
+"""]

--- a/src/data/components/navigation/variants.toml
+++ b/src/data/components/navigation/variants.toml
@@ -1,0 +1,15 @@
+[[variant]]
+id = "main_navigation"
+name = "Main Navigation"
+
+[[variant]]
+id = "topic_navigation"
+name = "Topic Navigation"
+
+[[variant]]
+id = "main_navigation_mobile"
+name = "Main Navigation - Mobile"
+
+[[variant]]
+id = "topic_navigation_mobile"
+name = "Topic Navigation - Mobile"

--- a/src/docs/content/components/navigation.md
+++ b/src/docs/content/components/navigation.md
@@ -1,0 +1,11 @@
+---
+title: "Navigation References"
+date: 2019-08-26T17:14:15-04:00
+draft: false
+type: component
+tags: ["component"]
+weight: 99
+description: "Reference examples for the Main and Topic navigations"
+component: "navigation"
+scripts: []
+---

--- a/src/docs/themes/rhd-docs/layouts/_default/baseof.html
+++ b/src/docs/themes/rhd-docs/layouts/_default/baseof.html
@@ -16,13 +16,13 @@
     <link rel="stylesheet" href="/css/prism-ghcolors.css">
     <script src="/js/base.js"></script>
     <script src="{{ $fontawesome.Permalink }}"></script>
-    
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.35.5/es6-shim.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.4/fetch.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/custom-elements-es5-adapter.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-bundle.js"></script>  
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.2.10/webcomponents-bundle.js"></script>
     <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/systemjs/3.1.6/system.min.js"></script> -->
     <!-- <script src="/js/require1k.min.js"></script> -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
@@ -32,7 +32,7 @@
     <script src="{{ (resources.Get "@rhd/rhd.min.js").Permalink }}"></script>
 
   </head>
-  <body>
+  <body class="pf-m-redhat-font">
     {{ partial "header.html" . }}
     <main role="main">
       <div class="layout-content">

--- a/src/docs/themes/rhd-docs/layouts/_default/single.html
+++ b/src/docs/themes/rhd-docs/layouts/_default/single.html
@@ -2,15 +2,15 @@
 {{ .Title }} – {{ .Site.Title }}
 {{ end }}
 {{ define "main" }}
-<header class="pfe-l-grid"><h1 class="pfe-m-10-col pfe-m-startat-2-col">{{ .Title }}</h1></header>
-<aside class="pfe-l-grid">
+<header class="pf-l-grid"><h1 class="pf-m-10-col pf-m-offset-1-col">{{ .Title }}</h1></header>
+<aside class="pf-l-grid">
     {{ with .PrevInSection }}
-        <a class="previous pfe-m-5-col pfe-m-startat-2-col" href="{{.Permalink}}"> {{.Title}}</a>
+        <a class="previous pf-m-5-col pf-m-offset-1-col" href="{{.Permalink}}"> {{.Title}}</a>
     {{ end }}
     {{ with .NextInSection }}
-        <a class="next pfe-m-5-col pfe-l--text-align--right" href="{{.Permalink}}"> {{.Title}}</a>
+        <a class="next pf-m-5-col pf-u-text-align--right" href="{{.Permalink}}"> {{.Title}}</a>
     {{ end }}
-    
+
 </aside>
 <section>{{ .Content }}</section>
 {{ with .Param "component" }}

--- a/src/docs/themes/rhd-docs/layouts/partials/component.html
+++ b/src/docs/themes/rhd-docs/layouts/partials/component.html
@@ -2,20 +2,19 @@
 {{ $contexts := .context }}
 <div class="pf-l-grid pf-m-gutter">
 {{ range $context := $contexts }}
-    <div class="pf-l-grid__item pf-m-12-col">
+    <div class="pf-l-grid__item pf-m-10-col pf-m-offset-1-col">
         <h2>{{ .details.name }}</h2>
     </div>
-    <!-- <div class="pfe-m-2-col"></div> -->
     {{ range $variants }}
-    {{if index $context .id}} 
+    {{if index $context .id}}
         {{if index $context .id "wrapper"}}
             {{ with index $context .id "wrapper" }}
                 {{.open | safeHTML }}
             {{end}}
         {{ else }}
-        <div class="pf-l-grid__item pf-m-5-col-on-sm pf-m-3-col-on-md pf-m-2-col-on-lg">
+        <div class="pf-l-grid__item pf-m-10-col pf-m-offset-1-col">
         {{ end }}
-            <h4>{{ .name }}</h4>
+            <h4 class="pf-c-title pf-m-lg">{{ .name }}</h4>
             {{with (index $context .id "templates")}}
             {{ range . }}
                 {{ . | safeHTML }}

--- a/src/docs/themes/rhd-docs/layouts/partials/component_old.html
+++ b/src/docs/themes/rhd-docs/layouts/partials/component_old.html
@@ -2,7 +2,7 @@
 {{ $templates := (shuffle .templates) }}
 {{ with .variant }}
     {{ range . }}
-        <h2>{{ .name }}</h2>
+        <h2 class="pf-c-title pf-m-2xl">{{ .name }}</h2>
         <ul>
             {{ range .context}}
             {{ .template | safeHTML }}
@@ -14,7 +14,7 @@
 {{ range . }}
     {{ $attr := .name }}
     <div style="padding: 0 16px">
-    <h2 class="pfe-m-12-col pfe-l--text-align--center">{{ $attr }}</h2>
+    <h2 class="pf-c-title pf-m-2xl pf-m-12-col pf-u-text-align--center">{{ $attr }}</h2>
     {{ range .values }}
         {{ $val := . }}
         {{ $txt := delimit (slice $attr "=" `"` . `"`) "" }}

--- a/src/docs/themes/rhd-docs/layouts/partials/header.html
+++ b/src/docs/themes/rhd-docs/layouts/partials/header.html
@@ -1,9 +1,9 @@
-<header role="banner" class="pfe-l-grid pfe-m-all-12-col">
+<header role="banner" class="pf-l-grid pf-m-all-12-col">
     <div class="rh-universal-header">
         <nav class="rh-nav-universal" aria-label="Red Hat Global Navigation">
             <!-- <a class="rh-logo-wrapper" id="home-link" href="https://www.redhat.com/" title="Red Hat Home page"> -->
                 <img class="rh-header-logo" alt="Red Hat Logo" src="https://developers.redhat.com/themes/custom/rhdp/images/branding/RHLogo_white.svg">
-            <!-- </a>            
+            <!-- </a>
             <ul class="rh-nav-universal-list">
                 <li class="rh-nav-universal-list-item">
                     <a class="rh-nav-universal-list-link" href="https://access.redhat.com/" title="Red Hat Customer Portal">Customer Portal</a>
@@ -36,13 +36,13 @@
             </ul>
         </nav>
     </div>
-    <div class="pfe-m-10-col pfe-m-startat-2-col">
+    <div class="pf-m-10-col pf-m-offset-1-col">
         <div class="rhd-masthead-inner">
             <div class="rhd-header">
                 <a href="/" title="Home" rel="home" class="rhd-header-logo">
                     <img src="https://developers.redhat.com/themes/custom/rhdp/logo.svg" alt="Home">
                 </a>
-                <nav role="navigation" aria-labelledby="rhd-navigation-menu" class="rhd-navigation-menu" data-block-plugin-id="system_menu_block:rhd-navigation">            
+                <nav role="navigation" aria-labelledby="rhd-navigation-menu" class="rhd-navigation-menu" data-block-plugin-id="system_menu_block:rhd-navigation">
                     <h2 class="visually-hidden" id="rhd-navigation-menu">RHD Primary Navigation</h2>
                     <ul class="rhd-menu">
                         {{ range $.Site.Taxonomies.categories.page }}

--- a/src/docs/themes/rhd-docs/layouts/shortcodes/code.html
+++ b/src/docs/themes/rhd-docs/layouts/shortcodes/code.html
@@ -1,5 +1,5 @@
-<div class="pfe-l-grid">
-<pre class="pfe-m-10-col pfe-m-startat-2-col" style="max-height: 10em;">
+<div class="pf-l-grid">
+<pre class="pf-m-10-col pf-m-offset-1-col" style="max-height: 10em;">
 <code class="language-html">{{ string .Inner }}</code>
 </pre>
 </div>

--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -10,6 +10,7 @@
 @import "components/cards";
 @import "components/dynamic-list";
 @import "components/product-download-hero";
+@import "components/navigation";
 
 pfe-cta {
   border-radius: 3px;

--- a/src/styles/rhd-theme/components/_navigation.scss
+++ b/src/styles/rhd-theme/components/_navigation.scss
@@ -26,7 +26,6 @@
       color: var(--pf-global--Color--300);
       font-weight: var(--pf-global--FontWeight--bold);
       text-align: center;
-      text-transform: uppercase;
       .rhd-m-nav-description {
         display: block;
         font-size: 12px;

--- a/src/styles/rhd-theme/components/_navigation.scss
+++ b/src/styles/rhd-theme/components/_navigation.scss
@@ -1,0 +1,88 @@
+.rhd-c-nav {
+  font-family: "RedHatDisplay", "Overpass", Overpass, Helvetica, Arial, sans-serif;
+  .pf-c-nav__tertiary-list .pf-c-nav__link,
+  .pf-c-nav__tertiary-list a {
+    color: var(--pf-global--Color--200);
+    font-weight: var(--pf-global--FontWeight--bold);
+  }
+  .pf-c-nav__tertiary-list .pf-c-nav__link.pf-m-current::after,
+  .pf-c-nav__tertiary-list .pf-c-nav__link.pf-m-hover::after,
+  .pf-c-nav__tertiary-list .pf-c-nav__link:hover::after,
+  .pf-c-nav__tertiary-list .pf-c-nav__link:focus::after,
+  .pf-c-nav__tertiary-list .pf-c-nav__link:active::after {
+    background-color: #c00;
+  }
+  &-dropdown {
+    .pf-c-dropdown__toggle {
+      padding: 12px var(--pf-global--spacer--md);
+      color: var(--pf-global--Color--300);
+    }
+    .pf-c-dropdown__toggle::before {
+      border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--Color--300);
+    }
+    li a {
+      padding: var(--pf-global--spacer--md);
+      display: block;
+      color: var(--pf-global--Color--300);
+      font-weight: var(--pf-global--FontWeight--bold);
+      text-align: center;
+      text-transform: uppercase;
+      .rhd-m-nav-description {
+        display: block;
+        font-size: 12px;
+        font-weight: var(--pf-global--FontWeight--normal);
+        text-transform: none;
+      }
+    }
+    li:first-child {
+      padding: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
+      background-color: var(--pf-global--BackgroundColor--dark-200) !important;
+      color: var(--pf-global--Color--light-100);
+    }
+    li:nth-child(2) {
+      padding: var(--pf-global--spacer--md);
+      background-color: var(--pf-global--Color--400) !important;
+    }
+    li:nth-child(odd) {
+      background-color: var(--pf-global--BackgroundColor--light-100);
+    }
+    li:nth-child(even) {
+      background-color: var(--pf-global--BackgroundColor--300);
+    }
+    &.rhd-m-expanded {
+      input {
+        border-color: transparent;
+      }
+      .pf-c-button.pf-m-tertiary::after {
+        border-color: transparent;
+      }
+      .pf-c-dropdown__menu {
+        top: 0;
+        right: 0;
+        border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--Color--300);
+        width: 250px;
+        padding: 0;
+      }
+    }
+  }
+}
+.rhd-c-nav--topics {
+  font-family: "RedHatDisplay", "Overpass", Overpass, Helvetica, Arial, sans-serif;
+  .pf-c-nav__tertiary-list .pf-c-nav__link,
+  .pf-c-nav__tertiary-list a {
+    color: var(--pf-global--Color--100);
+    font-weight: var(--pf-global--FontWeight--bold);
+  }
+  .pf-c-nav__tertiary-list .pf-c-nav__link.pf-m-current::after,
+  .pf-c-nav__tertiary-list .pf-c-nav__link.pf-m-hover::after,
+  .pf-c-nav__tertiary-list .pf-c-nav__link:hover::after,
+  .pf-c-nav__tertiary-list .pf-c-nav__link:focus::after,
+  .pf-c-nav__tertiary-list .pf-c-nav__link:active::after {
+    background-color: #c00;
+  }
+}
+
+.rhd-l-topics {
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--Color--100);
+  margin-bottom: var(--pf-global--spacer--md);
+}


### PR DESCRIPTION
Introduce the Main navigation and Topic navigation references. References include both the 'desktop' and 'mobile' viewport sizes - how the menus should react (whether horizontal scroll or hamburger menu) and what those reactions should look like.

Closes https://github.com/redhat-developer/rhd-frontend/issues/119

![navigation](https://user-images.githubusercontent.com/4032718/63945744-d82ca400-ca41-11e9-95f2-816d2883a65b.png)
