### PR TITLE
Remove duplicate font references

### DIFF
--- a/src/styles/2019/fonts/_fonts.scss
+++ b/src/styles/2019/fonts/_fonts.scss
@@ -1,1 +1,0 @@
-@import url('https://fonts.googleapis.com/css?family=Overpass:100,100i,200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i&subset=latin-ext');

--- a/src/styles/rhd-theme/_pf4-import.scss
+++ b/src/styles/rhd-theme/_pf4-import.scss
@@ -4,6 +4,9 @@
 // If desired, individual components can be commented out and not included in the application.
 //
 
+$pf-global--enable-font-overpass-cdn: true !default;
+$pf-global--disable-fontawesome: true !default;
+
 //custom rhd theme overrides
 @import "pf4-base-variable-overrides";
 @import "../../../node_modules/@patternfly/patternfly/patternfly.scss";

--- a/src/styles/rhd-theme/typography/_fonts.scss
+++ b/src/styles/rhd-theme/typography/_fonts.scss
@@ -1,5 +1,4 @@
 @import url('https://fonts.googleapis.com/css?family=Red+Hat+Display:400,500,700|Red+Hat+Text:400,500&display=swap');
-//@import url('https://fonts.googleapis.com/css?family=Overpass:100,100i,200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i&subset=latin-ext');
 
 $rhd-font-stack-display: ("RedHatDisplay", "Overpass", "Helvetica", "Arial", sans-serif);
 $rhd-font-stack-text: ("RedHatText", "Overpass", "Helvetica", "Arial", sans-serif);

--- a/src/styles/rhd.scss
+++ b/src/styles/rhd.scss
@@ -3,9 +3,7 @@
 
 $soft-dark: rgba(0,0,0,.8);
 $white: white;
-// @import "global";
 $gutter: 30px;
-//$fa-font-path: "../webfonts";
 
 .PFElement { position: relative; }
 
@@ -83,13 +81,6 @@ $gutter: 30px;
 .rh-nav-universal {
     --pfe-theme--color--ui-link: #{$white};
     --pfe-theme--link--text-decoration: none;
-
-    &-list {
-
-        &-item {
-
-        }
-    }
 }
 
 a {
@@ -98,15 +89,6 @@ a {
 /// Post-2018 redesign styles
 @import "2019/mixins";
 @import "2019/mq-mixins";
-// @import "fonts/fonts";
-// @import url('https://fonts.googleapis.com/css?family=Overpass:100,100i,200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i&subset=latin-ext');
-// @import "../@fortawesome/fontawesome-pro/scss/fontawesome.scss";
-// @import "../@fortawesome/fontawesome-pro/scss/regular.scss";
-// @import "../@fortawesome/fontawesome-pro/scss/light.scss";
-// @import "../@fortawesome/fontawesome-pro/scss/solid.scss";
-// @import "../@fortawesome/fontawesome-pro/scss/brands.scss";
-// @import "../@fortawesome/fontawesome-pro/scss/duotone.scss";
-// @import "colors";
 @import "2019/colors/brand";
 @import "2019/colors/accent";
 @import "2019/colors/grayscale";
@@ -130,7 +112,6 @@ a {
 
 * {
   box-sizing: border-box;
-  // font-family: "Overpass", "Open Sans", Arial, Helvetica, sans-serif;
   font-family: $rhd-font-stack-text;
   --pfe-theme--font-family: $rhd-font-stack-text;
   font-family: var(--pfe-theme--font-family, $rhd-font-stack-text);
@@ -143,62 +124,6 @@ h1, h2, h3, h4, h5, h6 {
 
 
 @import "2019/container";
-// @import "typography/typography";
-// a {
-//     color:$link;
-//     cursor:pointer;
-//     text-decoration: none;
-//     &:hover, &:focus, &:active { color: $linkhover; }
-//     &.dark-background{ color: $link-dark-background; }
-//     &.link-sm {color: $link-sm; }
-//     &.link-sm-dark {color: $link-sm-dark-background; }
-//     &:focus {
-//         outline-offset: 1px;
-//         outline-style: dotted;
-//         outline-width: 1px;
-//         outline-color: color($link);
-//     }
-//     &.img-link[href$=".pdf"] {
-//       .fa-file-pdf {
-//         display: none;
-//       }
-//     }
-// }
-
-// p a:not(.button):hover {
-//   border-bottom: 1px solid $grey-3-5;
-// }
-
-// p a.external-link:after {
-//   display: none;
-// }
-
-// small a,
-// .link-sm a { color: $link-sm; }
-
-// .menu-trigger {
-//   background: #FFF;
-//   color: #000;
-//   text-transform: uppercase;
-//   text-decoration: none;
-//   border: 1px solid #000;
-//   font-size: 16px;
-//   font-weight: 600;
-//   padding:9px 40px;
-//   -webkit-transition: background .2s ease-in 0s;
-//   transition:background .2s ease-in 0s;
-//   line-height: 1.44;
-//   margin-left: 0 !important;
-//   margin-right: 0 !important;
-//   &:hover, &:active, &:focus {
-//     background-color: #000;
-//   }
-// }
-
-
-// @import "patterns/patterns";
-// @import "assembly/assembly";
-// @import "foundation/foundation";
 @import "2019/backgrounds";
 @import "2019/spacing";
 @import "2019/navigation";


### PR DESCRIPTION
Set build variables to disable the Font Awesome references included in the PatternFly package.

Set the build to use the Overpass CDN, rather than look for local assets.

Clean up commented code and remove unnecessary font file.

Related to https://github.com/redhat-developer/rhd-frontend/issues/135