### PR TITLE
Updates layouts to utilize PatternFly Core

### DIFF
--- a/src/docs/content/_index.md
+++ b/src/docs/content/_index.md
@@ -2,46 +2,37 @@
 title: "Home"
 date: 2017-08-03T10:56:11-04:00
 draft: false
-scripts: ["@patternfly/pfe-card/pfe-card.umd"]
 ---
 
-# RHDP Documentation
+<h1 class="pf-c-title pf-m-3xl pf-u-mt-lg pf-u-mb-sm">RHDP Documentation</h1>
 
+<h2 class="pf-c-title pf-m-2xl pf-u-mt-lg pf-u-mb-sm">Patterns</h2>
 
-## Patterns
+- [Typography](patterns/design/typography/ "Typography Patterns")
+- [Buttons and CTAs](patterns/misc/btn-cta/ "Buttons and CTA Patterns")
+- [Alerts and Notifications](patterns/content/notifications/ "Alert and Notification Patterns")
 
-<pfe-card pfe-color="dark" class="rhd-m-link--type-manuals">
-    <h3 slot="pfe-card__header">
-        <a href="patterns/design/typography">Typography</a>
-    </h3>
-    <div slot="pfe-card__body">
-    Fonts, sizes, spacing, etc.
-    </div>
-</pfe-card>
-
-[Typography](patterns/design/typography/)
-
-[Buttons and CTAs](components/btn-cta/)
-
-[Alerts and Notifications](patterns/content/notifications/)
-
-## Components
+<h2 class="pf-c-title pf-m-2xl pf-u-mt-lg pf-u-mb-sm">Components</h2>
 
 * {{< fa "fas fa-search">}} [Search](components/search)
 * {{< fa "fas fa-film">}} [DevNationLive](components/devnationlive)
 * {{< fa "far fa-address-card">}} [OneBox](components/onebox)
 
+<h2 class="pf-c-title pf-m-2xl pf-u-mt-lg pf-u-mb-sm">Code</h2>
 
-## Code
+1. [SASS](styling "SASS Styling")
+1. [JavaScript](scripting "JavaScript")
 
-[SASS](styling)
-[JavaScript](scripting)
+<h2 class="pf-c-title pf-m-2xl pf-u-mt-lg pf-u-mb-sm">Helpful Links</h2>
 
-
-## Helpful Links
-
-[Official Red Hat Unified Web Style Guide](https://docs.google.com/document/d/1bAb9MkrLW34wtk4RtrYvqLylXnvWhS81aDHAjhSzxMQ/edit)
-
-[Customer Portal UX: Pattern Library Game Plan](https://docs.google.com/document/d/1VoHKCKPKLLNZC7N8i3KlsMSfZYpfFdRRWl3t01Sg2IA/edit#heading=h.he2yza8x0ytw)
-
-[Maintainable & Modular CSS](http://bit.ly/mod-css)
+<ul class="pf-c-list">
+  <li>
+    <a href="https://docs.google.com/document/d/1bAb9MkrLW34wtk4RtrYvqLylXnvWhS81aDHAjhSzxMQ/edit" class="pf-m-link">Official Red Hat Unified Web Style Guide</a> <i class="fas fa-external-link"></i> <span class="pf-c-label pf-m-compact">Requires Red Hat ID</span>
+  </li>
+  <li>
+    <a href="https://docs.google.com/document/d/1VoHKCKPKLLNZC7N8i3KlsMSfZYpfFdRRWl3t01Sg2IA/edit#heading=h.he2yza8x0ytw" class="pf-m-link">Customer Portal UX: Pattern Library Game Plan</a> <i class="fas fa-external-link"></i> <span class="pf-c-label pf-m-compact">Requires Red Hat ID</span>
+  </li>
+  <li>
+    <a href="http://bit.ly/mod-css" class="pf-m-link">Maintainable & Modular CSS</a> <i class="fas fa-external-link"></i>
+  </li>
+</ul>

--- a/src/docs/content/components/search.md
+++ b/src/docs/content/components/search.md
@@ -10,14 +10,14 @@ scripts: ["@patternfly/pfelement/pfelement.umd",
 "@fortawesome/fontawesome-svg-core/index",
 "@rhd/dp-search/dp-search-app",
 "@rhd/dp-search/dp-search-box",
-"@rhd/dp-search/dp-search-filter-group", 
+"@rhd/dp-search/dp-search-filter-group",
 "@rhd/dp-search/dp-search-filter-item",
 "@rhd/dp-search/dp-search-filters",
 "@rhd/dp-search/dp-search-onebox",
 "@rhd/dp-search/dp-search-query",
 "@rhd/dp-search/dp-search-result-count",
 "@rhd/dp-search/dp-search-result",
-"@rhd/dp-search/dp-search-results", 
+"@rhd/dp-search/dp-search-results",
 "@rhd/dp-search/dp-search-sort-page",
 "@rhd/dp-search/dp-search-url",
 "@rhd/dp-search/dp-search-modal-filters",
@@ -29,7 +29,6 @@ scripts: ["@patternfly/pfelement/pfelement.umd",
 <dp-search-box slot="query"></dp-search-box>
 <dp-search-filters title="Filter By" slot="filters">
     <dp-search-filter-group name="CONTENT TYPE" name="type">
-<<<<<<< HEAD
         <!-- <dp-search-filter-item group="type" key="topic_page" value="topic_page" name="Topic">Topic</dp-search-filter-item> -->
         <dp-search-filter-item group="type" key="article" value="article" name="Articles">Articles</dp-search-filter-item>
         <!-- <dp-search-filter-item group="type" key="product" value="product" name="Product">Product</dp-search-filter-item> -->
@@ -40,18 +39,6 @@ scripts: ["@patternfly/pfelement/pfelement.umd",
         <dp-search-filter-item slot="secondary" group="type" key="cheat_sheet" value="cheat_sheet" name="Cheat Sheet">Cheat Sheet</dp-search-filter-item>
         <dp-search-filter-item slot="secondary" group="type" key="coding_resource" value="coding_resource" name="Coding Resource">Coding Resource</dp-search-filter-item>
         <dp-search-filter-item slot="secondary" group="type" key="webpage" value="webpage" name="Webpage">Webpage</dp-search-filter-item>
-=======
-        <dp-search-filter-item group="type" key="topic_page" value="topic_page" name="Topic">Topic</dp-search-filter-item>
-        <dp-search-filter-item group="type" key="article,webpage,coding_resource,page" value="article" name="Article">Article</dp-search-filter-item>
-        <dp-search-filter-item group="type" key="product" value="product" name="Product">Product</dp-search-filter-item>
-        <dp-search-filter-item group="type" key="books" value="books" name="Books">Books</dp-search-filter-item>
-        <dp-search-filter-item group="type" key="video_resource" value="video_resource" name="Video">Video</dp-search-filter-item>
-        <dp-search-filter-item group="type" key="katacoda_course" value="katacoda_course,katacoda_individual_lesson" name="Katacoda Course">Katacoda Course</dp-search-filter-item>
-        <!-- <dp-search-filter-item slot="secondary" group="type" key="katacoda_individual_lesson" value="katacoda_individual_lesson" name="Katacoda Individual Lesson">Katacoda Individual Lesson</dp-search-filter-item> -->
-        <dp-search-filter-item group="type" key="cheat_sheet" value="cheat_sheet" name="Cheat Sheet">Cheat Sheet</dp-search-filter-item>
-        <!-- <dp-search-filter-item slot="secondary" group="type" key="coding_resource" value="coding_resource" name="Coding Resource">Coding Resource</dp-search-filter-item> -->
-        <!-- <dp-search-filter-item slot="secondary" group="type" key="webpage" value="webpage" name="Webpage">Webpage</dp-search-filter-item> -->
->>>>>>> 78d0de2e08710d624c087a63337ce71758dfa9fc
         <dp-search-filter-item slot="secondary" group="type" key="assembly_page" value="assembly_page" name="New Assembly Page">New Assembly Page</dp-search-filter-item>
         <dp-search-filter-item slot="secondary" group="type" key="author" value="author" name="Author">Author</dp-search-filter-item>
         <dp-search-filter-item slot="secondary" group="type" key="learning_path" value="learning_path" name="Learning Guides">Learning Guides</dp-search-filter-item>

--- a/src/docs/content/pages/home.md
+++ b/src/docs/content/pages/home.md
@@ -5,315 +5,86 @@ description: "A new Home page layout using PFE components"
 draft: false
 tags: ["page"]
 weight: 4
-scripts: ["@patternfly/pfe-cta/pfe-cta.umd", "@patternfly/pfe-card/pfe-card.umd", "@patternfly/pfe-band/pfe-band.umd", "@rhd/dp-alert"]
 ---
 
 <main role="main">
-  <a id="main-content" tabindex="-1"></a>
   <div id="block-rhdp-content" data-block-plugin-id="system_main_block">
     <article role="article" about="/home/">
-      <section id="assembly-field-sections-11325" class=" rhd-c-background-type__rich-text has-background">
+      <section>
         <div class="container">
-          <div class="pfe-l-grid pfe-m-all-6-col">
-            <div>
-              <img alt="helloworld" width="260" height="98" src="https://developers.redhat.com/sites/default/files/styles/large/public/RHEL-helloworld.png?itok=kTPVSU3E" class="pf-m-pb-2">
-              <p>Download your developer edition of Red Hat Enterprise Linux 8</p>
-              <pfe-cta priority="primary">
-                <a href="https://developers.redhat.com/rhel8/">Download</a>
-              </pfe-cta>
+          <div class="pf-l-grid">
+            <div class="pf-l-grid__item pf-m-12-col">
+              <img alt="RedHat-IBM" src="https://developers.redhat.com/sites/default/files/RedHat_IBM_logo%C2%AE_lockup_horiz_pos_color_RGB.png" class="pf-m-pb-2">
             </div>
-            <div>
-              <article class="embedded-entity">
-                <img src="https://developers.redhat.com/sites/default/files/OpenShift4_Logo_Black.png" alt="OpenShift4_Logo_Black" title="OpenShift4_Logo_Black" width="312" typeof="foaf:Image">
-              </article>
-              <p>The Kubernetes platform for big ideas</p>
-              <pfe-cta priority="primary">
-                <a href="https://developers.redhat.com/openshift/">Download</a>
-              </pfe-cta>
+          </div>
+          <div class="pf-l-grid">
+            <div class="pf-l-grid__item pf-m-6-col-on-md pf-m-offset-1-col-on-md">
+              <a class="pf-c-button pf-m-link">Learn about the Developer program <i class="fas fa-caret-right"></i></a>
+            </div>
+            <div class="pf-l-grid__item pf-m-5-col-on-md">
+              <a class="pf-c-button pf-m-link">Learn about Red Hat and communities <i class="fas fa-caret-right"></i></a>
             </div>
           </div>
         </div>
       </section>
-      <section id="assembly-field-sections-9225" class="rhd-u-content-spacer rhd-m-content-type--feed">
-        <div class="container narrow">
-          <h2 class="pfe-headline-1 pfe-l--text-align--center">
-            Build here
-          </h2>
-          <div class="pfe-l-grid pfe-m-gutters pfe-l-grid-fill-height pfe-m-all-3-col">
-            <pfe-card pfe-color="lightest" class="rhd-m-link--type-manuals">
-              <img src="https://developers.redhat.com/sites/default/files/styles/static_item/public/externals/dce8036d40e0b11dd1c1d0620e8ebe59.png?itok=092K5PjH">
-              <a href="https://developers.redhat.com/blog/2019/05/07/red-hat-enterprise-linux-8-developer-cheat-sheet/">
-                <h3 class="pfe-card--header">
-                  <a href="https://developers.redhat.com/blog/2019/05/07/red-hat-enterprise-linux-8-developer-cheat-sheet/">Red Hat Enterprise Linux 8 developer cheat sheet</a>
-                </h3>
-              </a>
-              <div class="tile-comment-count hidden" data-disqus-thread-link="https://developers.redhat.com/blog/2019/05/07/red-hat-enterprise-linux-8-developer-cheat-sheet/" data-disqus-comment-count="">
-                <a href="https://developers.redhat.com/blog/2019/05/07/red-hat-enterprise-linux-8-developer-cheat-sheet/#disqus_thread">
-                  <span class="fa fa-comment"></span>
-                  <span class="comment-number" data-disqus-comment-count-number=""></span>
-                  <span class="count-verbage" data-disqus-comment-count-verbage="">Comments</span>
-                </a>
-              </div>
-            </pfe-card>
-            <pfe-card pfe-color="lightest" class="rhd-m-link--type-manuals">
-              <img src="https://developers.redhat.com/sites/default/files/styles/static_item/public/externals/e82397e71d7ae42dd48a946b0a9a3e1f.png?itok=J7cA6g6b">
-              <a href="https://developers.redhat.com/blog/2019/05/07/red-hat-enterprise-linux-8-now-generally-available/">
-                <h3 class="pfe-card--header">
-                  Red Hat Enterprise Linux 8 now generally available</a>
-                </h3>
-              </a>
-              <div class="tile-comment-count hidden" data-disqus-thread-link="https://developers.redhat.com/blog/2019/05/07/red-hat-enterprise-linux-8-now-generally-available/" data-disqus-comment-count="">
-                <a href="https://developers.redhat.com/blog/2019/05/07/red-hat-enterprise-linux-8-now-generally-available/">
-                </a>
-                <a href="https://developers.redhat.com/blog/2019/05/07/red-hat-enterprise-linux-8-now-generally-available/#disqus_thread">
-                  <span class="fa fa-comment"></span>
-                  <span class="comment-number" data-disqus-comment-count-number=""></span>
-                  <span class="count-verbage" data-disqus-comment-count-verbage="">Comments</span>
-                </a>
-              </div>
-            </pfe-card>
-            <pfe-card pfe-color="lightest" class="rhd-m-link--type-manuals">
-              <img src="https://developers.redhat.com/sites/default/files/styles/static_item/public/externals/86fa8b876def478a861853d96654f01d.png?itok=tk2vh1wo">
-              <a href="https://developers.redhat.com/blog/2019/04/25/podman-basics-cheat-sheet/">
-                <h3 class="pfe-card--header">
-                  <a href="https://developers.redhat.com/blog/2019/04/25/podman-basics-cheat-sheet/">Podman basics cheat sheet</a>
-                </h3>
-              </a>
-              <div class="tile-comment-count hidden" data-disqus-thread-link="https://developers.redhat.com/blog/2019/04/25/podman-basics-cheat-sheet/" data-disqus-comment-count="">
-                <a href="https://developers.redhat.com/blog/2019/04/25/podman-basics-cheat-sheet/">
-                </a>
-                <a href="https://developers.redhat.com/blog/2019/04/25/podman-basics-cheat-sheet/#disqus_thread">
-                  <span class="fa fa-comment"></span>
-                  <span class="comment-number" data-disqus-comment-count-number=""></span>
-                  <span class="count-verbage" data-disqus-comment-count-verbage="">Comments</span>
-                </a>
-              </div>
-            </pfe-card>
-            <pfe-card pfe-color="lightest" class="rhd-m-link--type-manuals">
-              <img src="https://developers.redhat.com/sites/default/files/styles/static_item/public/externals/e684ea8849af25532d2f2c5ad1c6dab4.png?itok=x5vFfjEH">
-              <a href="https://developers.redhat.com/blog/2019/04/19/not-all-openjdk-12-builds-include-shenandoah-heres-why/">
-                <h3 class="pfe-card--header">
-                  <a href="https://developers.redhat.com/blog/2019/04/19/not-all-openjdk-12-builds-include-shenandoah-heres-why/">Not all OpenJDK 12 builds include Shenandoah: Here’s why</a>
-                </h3>
-              </a>
-              <div class="tile-comment-count hidden" data-disqus-thread-link="https://developers.redhat.com/blog/2019/04/19/not-all-openjdk-12-builds-include-shenandoah-heres-why/" data-disqus-comment-count="">
-                <a href="https://developers.redhat.com/blog/2019/04/19/not-all-openjdk-12-builds-include-shenandoah-heres-why/">
-                </a>
-                <a href="https://developers.redhat.com/blog/2019/04/19/not-all-openjdk-12-builds-include-shenandoah-heres-why/#disqus_thread">
-                  <span class="fa fa-comment"></span>
-                  <span class="comment-number" data-disqus-comment-count-number=""></span>
-                  <span class="count-verbage" data-disqus-comment-count-verbage="">Comments</span>
-                </a>
-              </div>
-            </pfe-card>
+      <section>
+        <div class="container">
+          <div class="pf-l-grid pf-m-gutter">
+            <div class="pf-l-grid__item">
+              <h2 class="pf-c-title pf-m-4xl pf-u-mb-md">
+                Build here
+              </h2>
+            </div>
           </div>
-        </section>
-        <section id="assembly-field-sections-345" class="rhd-u-content-spacer rhd-m-content-type--feed">
-          <div class="container">
-            <h2 class="pfe-headline-1 pfe-l--text-align--center">Go Anywhere</h2>
-            <div class="pfe-l-grid pfe-m-gutters">
-              <div class="pfe-m-9-col">
-                <article class="pfe-l-grid pfe-m-gutters rhd-m-content-teaser--list rhd-u-py-2xl">
-                  <div class="pfe-m-4-col rhd-u-py-lg">
-                    <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/e243d76bb39d5ac12184f0c855bf4e4c.png?itok=TaTJzkaz" alt="Bringing IoT to Red Hat AMQ Online" typeof="foaf:Image" class="image-style-teaser">
-                  </div>
-                  <div class="pfe-m-8-col rhd-u-py-lg">
-                    <h5 class="pfe-headline-5 rhd-u-mb-md">
-                      <a href="https://developers.redhat.com/blog/2019/05/14/bringing-iot-to-red-hat-amq-online/" class="pfe-headline-link">Bringing IoT to Red Hat AMQ Online</a>
-                    </h5>
-                    <div>May 14, 2019</div>
-                    <div>
-                      <p>Red Hat AMQ Online 1.1 was recently announced, and I am excited about it because it contains a tech preview of our Internet of Things (IoT) support. AMQ Online is the “messaging as service solution” from Red Hat AMQ. Leveraging the work we did on Eclipse Hono&nbsp;allows us to integrate a scalable, cloud-native IoT personality […]</p>
-                    </div>
-                  </div>
-                </article>
-                <article class="pfe-l-grid pfe-m-gutters rhd-m-content-teaser--list rhd-u-py-2xl">
-                  <div class="pfe-m-4-col rhd-u-py-lg">
-                    <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/d2dd1fb5e0433c79c97271b1d2a201b4.png?itok=d5C9OmA4" alt="Use the Kubernetes Python client from your running Red Hat OpenShift pods" typeof="foaf:Image" class="image-style-teaser">
-                  </div>
-                  <div class="pfe-m-8-col rhd-u-py-lg">
-                    <h5 class="pfe-headline-5 rhd-u-mb-md">
-                      <a href="https://developers.redhat.com/blog/2019/05/14/use-the-kubernetes-python-client-from-your-running-red-hat-openshift-pods/" class="pfe-headline-link">Use the Kubernetes Python client from your running Red Hat OpenShift pods</a>
-                    </h5>
-                    <div class="rhd-c-time">May 14, 2019</div>
-                    <div>
-                      <p>Red Hat OpenShift is part of the Cloud Native Computing Foundation (CNCF) Certified Program, ensuring portability and interoperability for your container workloads. This also allows you to use Kubernetes tools to interact with an OpenShift cluster, like kubectl, and you can rest assured that all the APIs you know and love are right there at […]</p>
-                    </div>
-                  </div>
-                </article>
-                <article class="pfe-l-grid pfe-m-gutters rhd-m-content-teaser--list rhd-u-py-2xl">
-                  <div class="pfe-m-4-col rhd-u-py-lg">
-                    <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/f54e08bd8f35b685ebe57bb2d5397f38.png?itok=pwHyQbrY" alt="Building and understanding reactive microservices using Eclipse Vert.x and distributed tracing" typeof="foaf:Image" class="image-style-teaser">
-                  </div>
-                  <div class="pfe-m-8-col rhd-u-py-lg">
-                    <h5 class="pfe-headline-5 rhd-u-mb-md">
-                      <a href="https://developers.redhat.com/blog/2019/05/13/building-and-understanding-reactive-microservices-using-eclipse-vert-x-and-distributed-tracing/" class="pfe-headline-link">Building and understanding reactive microservices using Eclipse Vert.x and distributed tracing</a>
-                    </h5>
-                    <div class="rhd-c-time">May 13, 2019</div>
-                    <div>
-                      <p>I recently had the opportunity to speak at Red Hat Summit 2019. In my session, titled “Vert.x application development with Jaeger distributed tracing,” I discussed how scalable event-driven applications could be built with Eclipse Vert.x, a Java Virtual Machine toolkit for building reactive applications. Thanks to many developer tools, creating these applications is no longer […]</p>
-                    </div>
-                  </div>
-                </article>
-                <article class="pfe-l-grid pfe-m-gutters rhd-m-content-teaser--list rhd-u-py-2xl">
-                  <div class="pfe-m-4-col rhd-u-py-lg">
-                    <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/b356646680e6c550c55f845b5b5ca6e6.jpg?itok=RIkej_V9" alt="Migrating Java applications to Quarkus, Part 2: Before and after" typeof="foaf:Image" class="image-style-teaser">
-                  </div>
-                  <div class="pfe-m-8-col rhd-u-py-lg">
-                    <h5 class="pfe-headline-5 rhd-u-mb-md">
-                      <a href="https://developers.redhat.com/blog/2019/05/13/migrating-java-applications-to-quarkus-part-2-before-and-after/" class="pfe-headline-link">Migrating Java applications to Quarkus, Part 2: Before and after</a>
-                    </h5>
-                    <div class="rhd-c-time">May 13, 2019</div>
-                    <div>
-                      <p>This article is a continuation of Migrating Java applications to Quarkus: Lessons learned, and here, I’ll make a comparison of performance metrics for building and running a Java app before and after Quarkus. My goal here is to demonstrate how awesome Quarkus is and maybe help you decide to use Quarkus to build your cool […]</p>
-                    </div>
-                  </div>
-                </article>
-                <article class="pfe-l-grid pfe-m-gutters rhd-m-content-teaser--list rhd-u-py-2xl">
-                  <div class="pfe-m-4-col rhd-u-py-lg">
-                    <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/b356646680e6c550c55f845b5b5ca6e6.jpg?itok=RIkej_V9" alt="Create your first Quarkus project with Eclipse IDE (Red Hat CodeReady Studio)" typeof="foaf:Image" class="image-style-teaser">
-                  </div>
-                  <div class="pfe-m-8-col rhd-u-py-lg">
-                    <h5 class="pfe-headline-5 rhd-u-mb-md">
-                      <a href="https://developers.redhat.com/blog/2019/05/09/create-your-first-quarkus-project-with-eclipse-ide-red-hat-codeready-studio/" class="pfe-headline-link">Create your first Quarkus project with Eclipse IDE (Red Hat CodeReady Studio)</a>
-                    </h5>
-                    <div class="rhd-c-time">May 9, 2019</div>
-                    <div>
-                      <p>You’ve probably heard about Quarkus, the Supersonic Subatomic Java framework tailored for Kubernetes and containers. In this article, I will show how easy is it to create and set up a Quarkus project in an Eclipse IDE based environment.</p>
-                    </div>
-                  </div>
-                </article>
-                <pfe-cta priority="secondary" class="PFElement rhd-u-my-xl">
-                  <a href="https://developers.redhat.com/blog/page/2/">More Articles</a>
-                </pfe-cta>
-              </div>
-              <aside  class="pfe-m-3-col rhd-u-p-md rhd-u-mt-2xl">
-                <div class="disqus rhd-m-background-white rhd-u-p-md">
-                  <h5 class="header">
-                    <span class="fa fa-comment"></span> Latest Comments
-                  </h5>
-                  <div>
-                    <div class="comment-wrapper">
-                      <div>
-                        <h6 class="rhd-comment-header rhd-u-my-md">Introducing CodeReady Linux Builder</h6>
-                        <div class="rhd-comment-body">“Redhat Linux 8”</div>
-                          <div class="rhd-comment-footer">
-                            <div class="date">May 14, 2019</div>
-                            <div class="reply"><a href="https://developers.redhat.com/blog/2018/11/15/introducing-codeready-linux-builder/#comment-4462244727" class="reply-link">Reply</a></div>
-                          </div>
-                        </div>
-                        <div>
-                          <h6 class="rhd-comment-header rhd-u-my-md">Red Hat Enterprise Linux 8 Image Builder: Building custom system images</h6>
-                          <div class="rhd-comment-body">“Glad you published this.  I am interested to see more based on using an Enterprise setup with Satellite and RHEL 8.”</div>
-                          <div class="rhd-comment-footer">
-                            <div class="date">May 14, 2019</div>
-                            <div class="reply"><a href="https://developers.redhat.com/blog/2019/03/28/red-hat-enterprise-linux-8-image-builder-building-custom-system-images/#comment-4462505117" class="reply-link">Reply</a></div>
-                          </div>
-                        </div>
-                        <div>
-                          <h6 class="rhd-comment-header rhd-u-my-md">Containers without daemons: Podman and Buildah available in RHEL 7.6 and RHEL 8 Beta</h6>
-                          <div class="rhd-comment-body">“How can I match existing containerization work in regards to docker version compatibility. So e.g if I want to run and build containers in the future based on my existing...”</div>
-                          <div class="rhd-comment-footer">
-                            <div class="date">May 14, 2019</div>
-                            <div class="reply"><a href="https://developers.redhat.com/blog/2018/11/20/buidah-podman-containers-without-daemons/#comment-4461975364" class="reply-link">Reply</a></div>
-                          </div>
-                        </div>
-                        <div>
-                          <h6 class="rhd-comment-header rhd-u-my-md">Create your first Quarkus project with Eclipse IDE (Red Hat CodeReady Studio)</h6>
-                          <div class="rhd-comment-body">“How do you stop it running? Stop button on the Console window does nothing.”</div>
-                          <div class="rhd-comment-footer">
-                            <div class="date">May 14, 2019</div>
-                            <div class="reply"><a href="https://developers.redhat.com/blog/2019/05/09/create-your-first-quarkus-project-with-eclipse-ide-red-hat-codeready-studio/#comment-4461751082" class="reply-link">Reply</a></div>
-                          </div>
-                        </div>
-                      </div>
-                    </aside>
-                  </div>
+          <div class="pf-l-grid pf-m-gutter">
+            <div class="pf-l-grid__item pf-m-9-col-on-md">
+              <div class="pf-l-grid pf-m-gutter">
+                <div class="pf-l-grid__item pf-m-12-col">
+                  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                  </p>
+                  <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>
                 </div>
-              </section>
-              <section class="rhd-u-content-spacer rhd-c-background-type__ebooks">
-                <div class="container">
-                  <h2 class="pfe-headline-1 pfe-l--text-align--center rhd-u-py-md">
-                    Red Hat Developer eBooks
-                  </h2>
-                  <div class="pfe-l-grid pfe-m-gutters">
-                    <div class="pfe-m-12-col">
-                      <div class="pfe-l-grid pfe-m-gutters pfe-m-all-3-col">
-                          <pfe-card pfe-color="lightest" class="rhd-m-link--type-books">
-                            <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/cover-image/2019-04/istio-service-mesh-microservices.png?itok=B8ITBwta" width="137" height="205" alt="Introducing Istio Service Mesh for Microservices" typeof="foaf:Image">
-                            <a href="/books/introducing-istio-service-mesh-microservices/">
-                              <p>
-                                <span class="login-required" title="Free for members">
-                                  <span class="fas fa-users"></span>
-                                </span>
-                                EBook
-                                <h3 class="pfe-headline-3">
-                                  <span class="field field--name-title field--type-string field--label-hidden">Introducing Istio Service Mesh for Microservices</span>
-                                </h3>
-                              </p>
-                            </a>
-                          </pfe-card>
-                          <pfe-card pfe-color="lightest" class="rhd-m-link--type-books">
-                            <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/building-reactive-microservices-in-java.png?itok=QH8RrWQH" width="136" height="205" alt="Building Reactive Microservices in Java" typeof="foaf:Image">
-                            <a href="/books/building-reactive-microservices-java/">
-                              <p>
-                                <span class="login-required" title="Free for members">
-                                  <span class="fas fa-users"></span>
-                                </span>
-                                EBook
-                                <h3 class="pfe-headline-3">
-                                  <span class="field field--name-title field--type-string field--label-hidden">Building Reactive Microservices in Java: Asynchronous and Event-Based Application Design</span>
-                                </h3>
-                              </p>
-                            </a>
-                          </pfe-card>
-                          <pfe-card pfe-color="lightest" class="rhd-m-link--type-books">
-                            <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/SOLPthumbnail_manning_camel.png?itok=1GPKUI-O" width="161" height="205" alt="Camel in Action Book Cover" typeof="foaf:Image">
-                            <a href="/books/selections-camel-action/">
-                              <p>
-                                <span class="login-required" title="Free for members">
-                                  <span class="fas fa-users"></span>
-                                </span>
-                                EBook
-                                <h3 class="pfe-headline-3">
-                                  <span class="field field--name-title field--type-string field--label-hidden">Selections from Camel in Action, 2nd Edition </span>
-                                </h3>
-                              </p>
-                            </a>
-                          </pfe-card>
-                          <pfe-card pfe-color="lightest" class="rhd-m-link--type-books">
-                            <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/microservices-for-java-developers.png?itok=D67LYN8Y" width="136" height="205" alt="Microservices for Java Developers" typeof="foaf:Image">
-                            <a href="/books/microservices-java-developers-hands-introduction-frameworks-and-containers/">
-                              <p>
-                                <span class="login-required" title="Free for members">
-                                  <span class="fas fa-users"></span>
-                                </span>
-                                EBook
-                                <h3 class="pfe-headline-3">
-                                  <span class="field field--name-title field--type-string field--label-hidden">Microservices for Java Developers: A Hands-on Introduction to Frameworks and Containers</span>
-                                </h3>
-                              </p>
-                            </a>
-                          </pfe-card>
-                          <pfe-card pfe-color="lightest" class="rhd-m-link--type-books">
-                            <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/migrating-to-microservice-databases.png?itok=ZOUaVymu" width="136" height="205" alt="Migrating to Microservice Databases" typeof="foaf:Image">
-                            <a href="/books/migrating-microservice-databases-relational-monolith-distributed-data/">
-                              <p>
-                                <i class="fas fa-users"></i> EBook
-                                <h3 class="pfe-headline-3">
-                                  <span class="field field--name-title field--type-string field--label-hidden">Migrating to Microservice Databases: From Relational Monolith to Distributed Data</span>
-                                </h3>
-                              </p>
-                            </a>
-                          </pfe-card>
+                <div class="pf-l-grid__item pf-m-12-col">
+                  <div class="pf-l-grid pf-m-gutter">
+                    <div class="pf-l-grid__item pf-m-4-col-on-md">
+                      <div class="pf-c-card rhd-c-card rhd-m-full-height">
+                        <div class="rhd-c-card__video">
+                          <img src="https://images.pexels.com/photos/417173/pexels-photo-417173.jpeg?cs=srgb&dl=altitude-clouds-cold-417173.jpg&fm=jpg">
+                        </div>
+                        <div class="rhd-c-card-content">
+                          <h3 class="rhd-c-card__title">
+                            Title of the video that can go to two lines, but will then hide until hovered
+                          </h3>
                         </div>
                       </div>
-                        <div class="pfe-m-12-col">
-                          <div class="pfe-l-grid">
-                            <div class="rhd-u-container-spacer-py-3xl">
-                              <pfe-cta priority="secondary">
-                                <a href="#">View all ebooks</a>
-                              </pfe-cta>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-4-col-on-md">
+                      <div class="pf-c-card rhd-c-card rhd-m-full-height">
+                        <div class="rhd-c-card-content">
+                          <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+                          <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by…</p>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--author">
+                              <a href="#" class="rhd-m-link">Author Name</a>
+                            </div>
+                            <div class="rhd-c-comment">
+                              <i class="fas fa-comment"></i> 2
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-4-col-on-md">
+                      <div class="pf-c-card rhd-c-card rhd-m-full-height">
+                        <div class="rhd-c-card-content">
+                          <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+                          <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by…</p>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--author">
+                              <a href="#" class="rhd-m-link">Author Name</a>
+                            </div>
+                            <div class="rhd-c-comment">
+                              <i class="fas fa-comment"></i> 2
                             </div>
                           </div>
                         </div>
@@ -321,64 +92,185 @@ scripts: ["@patternfly/pfe-cta/pfe-cta.umd", "@patternfly/pfe-card/pfe-card.umd"
                     </div>
                   </div>
                 </div>
-              </section>
-              <section class="rhd-u-content-spacer rhd-c-background-type__ebooks">
-                <div class="container">
-                  <h2 class="pfe-headline-1 pfe-l--text-align--center rhd-u-py-md">
-                    Red Hat Developer Cheat Sheets
-                  </h2>
-                  <div class="pfe-l-grid pfe-m-gutters">
-                    <div class="pfe-m-12-col">
-                      <div class="pfe-l-grid pfe-m-gutters pfe-m-all-3-col">
-                          <pfe-card pfe-color="lightest" class="rhd-m-link--type-books">
-                            <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/advandced-linux-commands-cheat-sheet-cover.png?itok=otFhp1Lu" width="136" height="205" alt="Advanced Linux Commands Cheat Sheet Image" typeof="foaf:Image">
-                            <a href="/cheat-sheets/advanced-linux-commands/">
-                              <p>
-                                <span class="login-required" title="Free for members">
-                                  <span class="fas fa-users"></span>
-                                </span>
-                                Cheat Sheet
-                                <h3 class="pfe-headline-3"><span class="field field--name-title field--type-string field--label-hidden">Advanced Linux Commands Cheat Sheet</span>
-                                </h3>
-                              </p>
-                            </a>
-                          </pfe-card>
-                          <pfe-card pfe-color="lightest" class="rhd-m-link--type-books">
-                            <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/kubernetes-cheat-sheet-cover.png?itok=io1KFs4d" width="136" height="205" alt="Kubernetes Cheat Sheet Image" typeof="foaf:Image">
-                            <a href="/cheat-sheets/kubernetes/">
-                              <p>
-                                <span class="login-required" title="Free for members">
-                                  <span class="fas fa-users"></span>
-                                </span>
-                                Cheat Sheet
-                                <h3 class="pfe-headline-3">
-                                  <span class="field field--name-title field--type-string field--label-hidden">Kubernetes Cheat Sheet</span>
-                                </h3>
-                              </p>
-                            </a>
-                          </pfe-card>
-                          <pfe-card pfe-color="lightest" class="rhd-m-link--type-books">
-                            <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/containers-cheat-sheet-cover.png?itok=yCnQBf3F" width="136" height="205" alt="Containers Cheat Sheet Image" typeof="foaf:Image">
-                            <a href="/cheat-sheets/containers/">
-                              <p>
-                                <span class="login-required" title="Free for members">
-                                  <span class="fas fa-users"></span>
-                                </span>
-                                Cheat Sheet
-                                <h3 class="pfe-headline-3">
-                                  <span class="field field--name-title field--type-string field--label-hidden">Containers Cheat Sheet</span>
-                                </h3>
-                              </p>
-                            </a>
-                          </pfe-card>
+              </div>
+            </div>
+            <div class="pf-l-grid__item pf-m-3-col-on-md">
+              <h3 class="pf-c-title pf-m-2xl pf-u-mb-md">Developer series</h3>
+              <div class="rhd-l-grid__list">
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title">
+                      <a href="#" class="rhd-m-link">Title of the series</a>&nbsp;
+                      <span class="rhd-m-list__comment">
+                        <i class="fas fa-newspaper"></i> 2
+                      </span>
+                    </h3>
+                    <div class="rhd-c-card__footer">
+                      <div class="rhd-c-card__footer--author">
+                        <a href="#" class="rhd-m-link">Author Name</a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title">
+                      <a href="#" class="rhd-m-link">Title of the series</a>&nbsp;
+                      <span class="rhd-m-list__comment">
+                        <i class="fas fa-newspaper"></i> 2
+                      </span>
+                    </h3>
+                    <div class="rhd-c-card__footer">
+                      <div class="rhd-c-card__footer--author">
+                        <a href="#" class="rhd-m-link">Author Name</a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title">
+                      <a href="#" class="rhd-m-link">Title of the series</a>&nbsp;
+                      <span class="rhd-m-list__comment">
+                        <i class="fas fa-newspaper"></i> 2
+                      </span>
+                    </h3>
+                    <div class="rhd-c-card__footer">
+                      <div class="rhd-c-card__footer--author">
+                        <a href="#" class="rhd-m-link">Author Name</a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="pf-u-my-3xl">
+        <div class="container">
+          <div class="pf-l-grid pf-m-gutter">
+            <div class="pf-l-grid__item">
+              <h2 class="pf-c-title pf-m-4xl pf-u-mb-md">
+                Go anywhere
+              </h2>
+            </div>
+          </div>
+          <div class="pf-l-grid pf-m-gutter">
+            <div class="pf-l-grid__item pf-m-9-col-on-md">
+              <div class="pf-l-grid">
+                <div class="pf-l-grid__item pf-m-12-col">
+                  <div class="pf-l-grid pf-m-gutter pf-u-pt-sm pf-u-pb-sm">
+                    <div class="pf-l-grid__item pf-m-4-col-on-lg pf-m-5-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column">
+                      <picture class="product-download-hero-aside">
+                        <source media="(min-width: 480px)" srcset="https://images.pexels.com/photos/714258/pexels-photo-714258.jpeg?cs=srgb&dl=adventure-alpine-alps-714258.jpg">
+                        <source media="(min-width: 768px)" srcset="https://images.pexels.com/photos/714258/pexels-photo-714258.jpeg?cs=srgb&dl=adventure-alpine-alps-714258.jpg">
+                        <source media="(min-width: 1024px)" srcset="https://images.pexels.com/photos/714258/pexels-photo-714258.jpeg?cs=srgb&dl=adventure-alpine-alps-714258.jpg">
+                        <img src="https://images.pexels.com/photos/714258/pexels-photo-714258.jpeg?cs=srgb&dl=adventure-alpine-alps-714258.jpg" alt="" class="">
+                      </picture>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-8-col-on-lg pf-m-7-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-flex-direction-column pf-c-content">
+                      <div class="product-download-hero-header">
+                        <h1 class="pf-c-title pf-m-lg pf-u-mb-0"><a href="#">API-first design with OpenAPI and Red Hat Fuse</a></h1>
+                        <small class="pf-u-mb-sm">July 8th, 2019</small>
+                      </div>
+                      <div class="product-download-hero-body">
+                        <p>API-first design is a commonly used approach where you define the interfaces for your application before providing an actual implementation. This approach gives you a lot of benefits. For example, you can test whether your API has the right structure before investing a lot of time implementing it, and you can share your ideas with...</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="pf-l-grid__item pf-m-12-col">
+                  <div class="pf-l-grid pf-m-gutter pf-u-pt-sm pf-u-pb-sm">
+                    <div class="pf-l-grid__item pf-m-4-col-on-lg pf-m-5-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-justify-content-center pf-u-flex-direction-column">
+                      <picture class="product-download-hero-aside">
+                        <source media="(min-width: 480px)" srcset="https://images.pexels.com/photos/714258/pexels-photo-714258.jpeg?cs=srgb&dl=adventure-alpine-alps-714258.jpg">
+                        <source media="(min-width: 768px)" srcset="https://images.pexels.com/photos/714258/pexels-photo-714258.jpeg?cs=srgb&dl=adventure-alpine-alps-714258.jpg">
+                        <source media="(min-width: 1024px)" srcset="https://images.pexels.com/photos/714258/pexels-photo-714258.jpeg?cs=srgb&dl=adventure-alpine-alps-714258.jpg">
+                        <img src="https://images.pexels.com/photos/714258/pexels-photo-714258.jpeg?cs=srgb&dl=adventure-alpine-alps-714258.jpg" alt="" class="">
+                      </picture>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-8-col-on-lg pf-m-7-col-on-md pf-m-6-col-on-sm pf-u-display-flex pf-u-flex-direction-column pf-c-content">
+                      <div class="product-download-hero-header">
+                        <h1 class="pf-c-title pf-m-lg pf-u-mb-0"><a href="#">API-first design with OpenAPI and Red Hat Fuse</a></h1>
+                        <small class="pf-u-mb-sm">July 8th, 2019</small>
+                      </div>
+                      <div class="product-download-hero-body">
+                        <p>API-first design is a commonly used approach where you define the interfaces for your application before providing an actual implementation. This approach gives you a lot of benefits. For example, you can test whether your API has the right structure before investing a lot of time implementing it, and you can share your ideas with...</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="pf-l-grid__item pf-m-3-col-on-md">
+              <h3 class="pf-c-title pf-m-2xl pf-u-mb-md">Latest articles</h3>
+              <div class="rhd-l-grid__list">
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+                    <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. <span class="rhd-m-list__comment"><i class="fas fa-comment"></i> 2</span></p>
+                  </div>
+                </div>
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+                    <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. <span class="rhd-m-list__comment"><i class="fas fa-comment"></i> 2</span></p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="pf-u-my-3xl">
+        <div class="container">
+          <div class="pf-l-grid pf-m-gutter">
+            <div class="pf-l-grid__item">
+              <h2 class="pf-c-title pf-m-4xl pf-u-mb-md">
+                Featured Red Hat products
+              </h2>
+            </div>
+          </div>
+          <div class="pf-l-grid pf-m-gutter">
+            <div class="pf-l-grid__item pf-m-9-col-on-md">
+              <div class="pf-l-grid">
+                <div class="pf-l-grid__item pf-m-12-col">
+                  <div class="pf-l-grid pf-m-gutter">
+                    <div class="pf-l-grid__item pf-m-4-col-on-md">
+                      <div class="pf-c-card rhd-c-card">
+                        <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/fc954fdb2506fde810a74701776127e6.png?itok=y5At3nm0" class="rhd-c-card__image">
+                        <div class="rhd-c-card-content">
+                          <p class="rhd-c-card__body">A stable, proven foundation that’s versatile enough for rolling out new applications, virtualizing environments, and creating a secure hybrid cloud.</p>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--download">
+                              <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
+                            </div>
+                          </div>
                         </div>
                       </div>
-                        <div class="pfe-m-12-col">
-                          <div class="pfe-l-grid">
-                            <div class="rhd-u-container-spacer-py-3xl">
-                              <pfe-cta priority="secondary">
-                                <a href="#">View all cheat sheets</a>
-                              </pfe-cta>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-4-col-on-md">
+                      <div class="pf-c-card rhd-c-card">
+                        <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/fc954fdb2506fde810a74701776127e6.png?itok=y5At3nm0" class="rhd-c-card__image">
+                        <div class="rhd-c-card-content">
+                          <p class="rhd-c-card__body">A stable, proven foundation that’s versatile enough for rolling out new applications, virtualizing environments, and creating a secure hybrid cloud.</p>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--download">
+                              <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-4-col-on-md">
+                      <div class="pf-c-card rhd-c-card">
+                        <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/fc954fdb2506fde810a74701776127e6.png?itok=y5At3nm0" class="rhd-c-card__image">
+                        <div class="rhd-c-card-content">
+                          <p class="rhd-c-card__body">A stable, proven foundation that’s versatile enough for rolling out new applications, virtualizing environments, and creating a secure hybrid cloud.</p>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--download">
+                              <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
                             </div>
                           </div>
                         </div>
@@ -386,38 +278,130 @@ scripts: ["@patternfly/pfe-cta/pfe-cta.umd", "@patternfly/pfe-card/pfe-card.umd"
                     </div>
                   </div>
                 </div>
-              </section>
-              <section class="rhd-e-section-blue rhd-u-content-spacer">
-                <div class="container">
-                  <div class="pfe-l-bullseye">
-                    <div class="pfe-l-bullseye__item pfe-l--text-align--center">
-                      <h2 class="pfe-headline-xxl">
-                        Join us for our next live developer tech talk.
-                      </h2>
-                      <p class="pfe-l--text-align--center">DevNation Live: Subatomic reactive systems with Quarkus</p>
-                      <p class="pfe-l--text-align--center">Presented by&nbsp;Clememt Escoffier on May 16, 2019 at 12:00 PM ET</p>
-                      <pfe-cta priority="primary" class="rhd-u-py-md">
-                        <a href="https://onlinexperiences.com/Launch/QReg/ShowUUID=F6BB8BA6-5AB4-4DC0-B592-5ABC912BBC61">Register Now</a>
-                      </pfe-cta>
+              </div>
+            </div>
+            <div class="pf-l-grid__item pf-m-3-col-on-md">
+              <h3 class="pf-c-title pf-m-2xl pf-u-mb-md">Related products</h3>
+              <div class="rhd-l-grid__list">
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Red Hat Enterprise Linux</a></h3>
+                  </div>
+                </div>
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Red Hat Enterprise Linux</a></h3>
+                  </div>
+                </div>
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Red Hat Enterprise Linux</a></h3>
+                  </div>
+                </div>
+                <div class="pf-c-card rhd-c-card__list">
+                  <div class="rhd-c-card-content">
+                    <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Red Hat Enterprise Linux</a></h3>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="pf-u-my-3xl">
+        <div class="container">
+          <div class="pf-l-grid pf-m-gutter">
+            <div class="pf-l-grid__item">
+              <h2 class="pf-c-title pf-m-4xl pf-u-mb-md">
+                Featured resources
+              </h2>
+            </div>
+          </div>
+          <div class="pf-l-grid pf-m-gutter">
+            <div class="pf-l-grid__item pf-m-12-col">
+              <div class="pf-l-grid">
+                <div class="pf-l-grid__item pf-m-12-col">
+                  <div class="pf-l-grid pf-m-gutter">
+                    <div class="pf-l-grid__item pf-m-3-col-on-md">
+                      <div class="pf-c-card rhd-c-card">
+                        <img src="https://images.pexels.com/photos/414171/pexels-photo-414171.jpeg?cs=srgb&amp;dl=adventure-calm-clouds-414171.jpg&amp;fm=jpg" class="rhd-c-card__image">
+                        <div class="rhd-c-card__tag">
+                          <i class="far fa-clone"></i> Cheat sheet
+                        </div>
+                        <div class="rhd-c-card-content">
+                          <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Kubernetes cheat sheet title that can go to two lines only and then must truncate after it passes two lines.</a></h3>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--author">
+                              <a href="#" class="rhd-m-link">Author Name</a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-3-col-on-md">
+                      <div class="pf-c-card rhd-c-card">
+                        <img src="https://images.pexels.com/photos/414171/pexels-photo-414171.jpeg?cs=srgb&amp;dl=adventure-calm-clouds-414171.jpg&amp;fm=jpg" class="rhd-c-card__image">
+                        <div class="rhd-c-card__tag">
+                          <i class="far fa-clone"></i> Cheat sheet
+                        </div>
+                        <div class="rhd-c-card-content">
+                          <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Kubernetes cheat sheet title that can go to two lines only and then must truncate after it passes two lines.</a></h3>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--author">
+                              <a href="#" class="rhd-m-link">Author Name</a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-3-col-on-md">
+                      <div class="pf-c-card rhd-c-card">
+                        <img src="https://images.pexels.com/photos/414171/pexels-photo-414171.jpeg?cs=srgb&amp;dl=adventure-calm-clouds-414171.jpg&amp;fm=jpg" class="rhd-c-card__image">
+                        <div class="rhd-c-card__tag">
+                          <i class="far fa-clone"></i> Cheat sheet
+                        </div>
+                        <div class="rhd-c-card-content">
+                          <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Kubernetes cheat sheet title that can go to two lines only and then must truncate after it passes two lines.</a></h3>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--author">
+                              <a href="#" class="rhd-m-link">Author Name</a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="pf-l-grid__item pf-m-3-col-on-md">
+                      <div class="pf-c-card rhd-c-card">
+                        <img src="https://images.pexels.com/photos/414171/pexels-photo-414171.jpeg?cs=srgb&amp;dl=adventure-calm-clouds-414171.jpg&amp;fm=jpg" class="rhd-c-card__image">
+                        <div class="rhd-c-card__tag">
+                          <i class="far fa-clone"></i> Cheat sheet
+                        </div>
+                        <div class="rhd-c-card-content">
+                          <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Kubernetes cheat sheet title that can go to two lines only and then must truncate after it passes two lines.</a></h3>
+                          <div class="rhd-c-card__footer">
+                            <div class="rhd-c-card__footer--author">
+                              <a href="#" class="rhd-m-link">Author Name</a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="pf-c-expandable pf-u-mt-sm">
+                    <button type="button" class="pf-c-expandable__toggle" aria-expanded="false">
+                      <i class="fas fa-angle-right pf-c-expandable__toggle-icon" aria-hidden="true"></i>
+                      <span>View all cheat sheets</span>
+                    </button>
+                    <div class="pf-c-expandable__content" hidden>
+                      This content is visible only when the component is expanded.
                     </div>
                   </div>
                 </div>
-              </section>
-              <section id="assembly-field-sections-7105" class="rhd-u-content-spacer">
-                <div class="container">
-                  <h1 class="pfe-headline-xxl rhd-u-py-md">Developer Tutorials and Red Hat Software for Cloud Application Development</h1>
-                  <p class="rhd-u-pb-md">Join Red Hat Developer for the tools and training to develop applications for the cloud. Members get access to developer editions of Red Hat’s software, documentation, and premium books from our experts on microservices, serverless, Kubernetes, and Linux.</p>
-                  <h2 class="pfe-headline-1 rhd-u-py-md">Cloud-Native Developer Career Training</h2>
-                  <p class="rhd-u-pb-md">Today’s containerized applications are changing development work requiring developers to adopt new architectures and DevOps (link to topic) processes. &nbsp;Red Hat Developer helps you build these skills and provides you with the tools you need to use them in your next application and beyond. Build here. Go anywhere.</p>
-                  <pfe-cta priority="primary" class="rhd-u-my-md rhd-u-mr-md">
-                    <a href="https://developers.redhat.com/register/?intcmp=701f2000001OMHaAAO">Join Red Hat Developer</a>
-                  </pfe-cta>
-                  <pfe-cta priority="secondary" class="rhd-u-my-md">
-                    <a href="/articles/red-hat-developer-program-benefits/">Learn more</a>
-                  </pfe-cta>
-                </div>
               </div>
-            </section>
+            </div>
+          </div>
+        </div>
+      </section>
     </article>
   </div>
 </main>

--- a/src/docs/content/patterns/layout/grid.md
+++ b/src/docs/content/patterns/layout/grid.md
@@ -5,36 +5,36 @@ draft: false
 tags: ["layout"]
 ---
 
-{{< code >}}<section class="pfe-l-grid pfe-m-gutters">
+{{< code >}}<section class="pf-l-grid pf-m-gutter">
     <div class="" style="padding: 1em; background-color:orange; height: 50px;">
         No Column Width
     </div>
 </section>{{< /code >}}
-{{< code >}}<section class="pfe-l-grid pfe-m-gutters">
-    <div class="pfe-m-6-col pfe-m-startat-4-col" style="padding: 1em; background-color:orange; height: 50px;">
+{{< code >}}<section class="pf-l-grid pf-m-gutter">
+    <div class="pf-m-6-col pf-m-offset-6-col" style="padding: 1em; background-color:orange; height: 50px;">
         Static Column Width: 6
     </div>
 </section>{{< /code >}}
-{{< code >}}<section class="pfe-l-grid pfe-m-gutters">
-    <div class="pfe-m-10-col-on-lg pfe-m-startat-2-col-on-lg" style="padding: 1em; background-color:red; height: 50px;">
+{{< code >}}<section class="pf-l-grid pf-m-gutter">
+    <div class="pf-m-10-col-on-lg pf-m-offset-2-col-on-lg" style="padding: 1em; background-color:red; height: 50px;">
         Dynamic Column Width: 10
     </div>
 </section>{{< /code >}}
-{{< code >}}<section class="pfe-l-grid pfe-m-gutters">
-    <div class="pfe-m-8-col-on-lg pfe-m-startat-3-col-on-lg" style="padding: 1em; background-color:green; height: 50px;">
+{{< code >}}<section class="pf-l-grid pf-m-gutter">
+    <div class="pf-m-8-col-on-lg pf-m-offset-4-col-on-lg" style="padding: 1em; background-color:green; height: 50px;">
         Dynamic Column Width: 8
     </div>
 </section>{{< /code >}}
-{{< code >}}<section class="pfe-l-grid pfe-m-gutters">
-    <div class="pfe-m-6-col-on-lg pfe-m-startat-4-col-on-lg" style="padding: 1em; background-color:blue; height: 50px;">
+{{< code >}}<section class="pf-l-grid pf-m-gutter">
+    <div class="pf-m-6-col-on-lg pf-m-offset-5-col-on-lg" style="padding: 1em; background-color:blue; height: 50px;">
         Dynamic Column Width: 6
     </div>
 </section>{{< /code >}}
-{{< code >}}<section class="pfe-l-grid pfe-m-gutters">
-    <div class="pfe-l-grid pfe-m-gutters pfe-m-all-6-col" style="padding:var(--pfe-theme--container-spacer);">
+{{< code >}}<section class="pf-l-grid pf-m-gutter">
+    <div class="pf-l-grid pf-m-gutter pf-m-all-6-col" style="padding:var(--pf-theme--container-spacer);">
         <div>
             <div style="background: #EEE;">
-                <div style="padding:var(--pfe-theme--container-spacer);">No Column Width</div>
+                <div style="padding:var(--pf-theme--container-spacer);">No Column Width</div>
             </div>
         </div>
         <div>
@@ -49,8 +49,8 @@ tags: ["layout"]
         </div>
     </div>
 </section>{{< /code >}}
-{{< code >}}<section class="pfe-l-grid pfe-m-gutters">
-    <div class="pfe-l-grid pfe-m-gutters pfe-m-all-4-col" style="background-color:orange;padding:var(--pfe-theme--container-spacer);">
+{{< code >}}<section class="pf-l-grid pf-m-gutter">
+    <div class="pf-l-grid pf-m-gutter pf-m-all-4-col" style="background-color:orange;padding:var(--pf-theme--container-spacer);">
         <div>
             <div style="background: #EEE;">
                 <div style="padding: 16px;">No Column Width</div>

--- a/src/docs/themes/rhd-docs/layouts/partials/component-table.html
+++ b/src/docs/themes/rhd-docs/layouts/partials/component-table.html
@@ -1,6 +1,6 @@
 {{ $variants := sort .variants.variant "order" }}
 {{ $contexts := .context }}
-<table>
+<table class="pf-c-table pf-m-grid-md" role="grid" aria-label="This is the component table" id="componentTable">
     <thead>
         <tr><th></th>
         {{ range $variants }}
@@ -13,7 +13,7 @@
         <tr>
             <td>{{ .details.name }}</td>
             {{ range $variants }}
-                {{if index $context .id}} 
+                {{if index $context .id}}
                 <td>{{with (index $context .id "templates")}}
                     {{ range . }}
                         {{ . | safeHTML }}

--- a/src/docs/themes/rhd-docs/layouts/partials/component.html
+++ b/src/docs/themes/rhd-docs/layouts/partials/component.html
@@ -2,7 +2,7 @@
 {{ $contexts := .context }}
 <div class="pf-l-grid pf-m-gutter">
 {{ range $context := $contexts }}
-    <div class="pf-l-grid__item pf-m-10-col pf-m-offset-1-col">
+    <div class="pf-l-grid__item pf-m-offset-1-col">
         <h2>{{ .details.name }}</h2>
     </div>
     {{ range $variants }}
@@ -12,7 +12,7 @@
                 {{.open | safeHTML }}
             {{end}}
         {{ else }}
-        <div class="pf-l-grid__item pf-m-10-col pf-m-offset-1-col">
+        <div class="pf-l-grid__item pf-m-offset-1-col">
         {{ end }}
             <h4 class="pf-c-title pf-m-lg">{{ .name }}</h4>
             {{with (index $context .id "templates")}}

--- a/src/docs/themes/rhd-docs/layouts/partials/header.html
+++ b/src/docs/themes/rhd-docs/layouts/partials/header.html
@@ -1,68 +1,68 @@
 <header role="banner" class="pf-l-grid pf-m-all-12-col">
-    <div class="rh-universal-header">
-        <nav class="rh-nav-universal" aria-label="Red Hat Global Navigation">
-            <!-- <a class="rh-logo-wrapper" id="home-link" href="https://www.redhat.com/" title="Red Hat Home page"> -->
-                <img class="rh-header-logo" alt="Red Hat Logo" src="https://developers.redhat.com/themes/custom/rhdp/images/branding/RHLogo_white.svg">
-            <!-- </a>
-            <ul class="rh-nav-universal-list">
-                <li class="rh-nav-universal-list-item">
-                    <a class="rh-nav-universal-list-link" href="https://access.redhat.com/" title="Red Hat Customer Portal">Customer Portal</a>
-                </li>
-                <li class="rh-nav-universal-link">
-                    <a class="rh-nav-universal-list-link" href="/" title="Red Hat Developer" data-drupal-link-system-path="<front>">Developer</a>
-                </li>
-                <li class="rh-nav-universal-link">
-                    <a class="rh-nav-universal-list-link" href="https://www.openshift.com/" title="Red Hat OpenShift Container Platform">OpenShift</a>
-                </li>
-                <li class="rh-nav-universal-link">
-                    <a class="rh-nav-universal-list-link" href="https://openshift.io/" title="Red Hat OpenShift.io Development Environment">OpenShift.io</a>
-                </li>
-                <li class="rh-nav-universal-link">
-                    <a class="rh-nav-universal-list-link" href="https://www.redhat.com/en/partners" title="Partner with Red Hat">Partners</a>
-                </li>
-                <li class="rh-nav-universal-link">
-                    <a class="rh-nav-universal-list-link" href="https://www.redhat.com/en/store" title="Red Hat Store">Store</a>
-                </li>
+  <div class="rh-universal-header">
+    <nav class="rh-nav-universal" aria-label="Red Hat Global Navigation">
+      <!-- <a class="rh-logo-wrapper" id="home-link" href="https://www.redhat.com/" title="Red Hat Home page"> -->
+        <img class="rh-header-logo" alt="Red Hat Logo" src="https://developers.redhat.com/themes/custom/rhdp/images/branding/RHLogo_white.svg">
+        <!-- </a>
+          <ul class="rh-nav-universal-list">
+            <li class="rh-nav-universal-list-item">
+              <a class="rh-nav-universal-list-link" href="https://access.redhat.com/" title="Red Hat Customer Portal">Customer Portal</a>
+            </li>
+            <li class="rh-nav-universal-link">
+              <a class="rh-nav-universal-list-link" href="/" title="Red Hat Developer" data-drupal-link-system-path="<front>">Developer</a>
+              </li>
+              <li class="rh-nav-universal-link">
+                <a class="rh-nav-universal-list-link" href="https://www.openshift.com/" title="Red Hat OpenShift Container Platform">OpenShift</a>
+              </li>
+              <li class="rh-nav-universal-link">
+                <a class="rh-nav-universal-list-link" href="https://openshift.io/" title="Red Hat OpenShift.io Development Environment">OpenShift.io</a>
+              </li>
+              <li class="rh-nav-universal-link">
+                <a class="rh-nav-universal-list-link" href="https://www.redhat.com/en/partners" title="Partner with Red Hat">Partners</a>
+              </li>
+              <li class="rh-nav-universal-link">
+                <a class="rh-nav-universal-list-link" href="https://www.redhat.com/en/store" title="Red Hat Store">Store</a>
+              </li>
             </ul>
             <ul class="rh-universal-login">
-                <li class="rh-nav-universal-logged-in-link">
-                    <ul class="rh-user-menu">
-                        <li class="rh-user-menu-item" data-auth-required="true"><a class="account-info" href="#">Account Info</a></li>
-                    </ul>
-                </li> -->
-                <!-- <li class="menu-item">
-                    <a href="/user/logout" data-drupal-link-system-path="user/logout">Log out</a>
-                </li> -->
+              <li class="rh-nav-universal-logged-in-link">
+                <ul class="rh-user-menu">
+                  <li class="rh-user-menu-item" data-auth-required="true"><a class="account-info" href="#">Account Info</a></li>
+                </ul>
+              </li> -->
+              <!-- <li class="menu-item">
+                <a href="/user/logout" data-drupal-link-system-path="user/logout">Log out</a>
+              </li> -->
             </ul>
-        </nav>
-    </div>
-    <div class="pf-m-10-col pf-m-offset-1-col">
-        <div class="rhd-masthead-inner">
+          </nav>
+        </div>
+        <div class="pf-m-10-col pf-m-offset-1-col">
+          <div class="rhd-masthead-inner">
             <div class="rhd-header">
-                <a href="/" title="Home" rel="home" class="rhd-header-logo">
-                    <img src="https://developers.redhat.com/themes/custom/rhdp/logo.svg" alt="Home">
-                </a>
-                <nav role="navigation" aria-labelledby="rhd-navigation-menu" class="rhd-navigation-menu" data-block-plugin-id="system_menu_block:rhd-navigation">
-                    <h2 class="visually-hidden" id="rhd-navigation-menu">RHD Primary Navigation</h2>
-                    <ul class="rhd-menu">
-                        {{ range $.Site.Taxonomies.categories.page }}
-                        <li class="menu-item rhd-header-link"><a href="{{ .Permalink }}">{{ .Title }}</a></li>
-                        {{ end }}
-                        <!-- <li class="rhd-nav-search">
-                            <div class="rhd-search-wrapper">
-                                <form class="search-bar" accept-charset="utf-8" action="./search/" method="get" role="search" type="submit" data-drupal-form-fields="search_list_text">
-                                    <input class="user-search" type="text" placeholder="Search" id="search_list_text" name="t" maxlength="128" required="">
-                                    <button type="submit" id="search-button"><i class="far fa-search"></i></button>
-                                </form>
-                            </div>
-                            <button class="rhd-search-toggle"><span class="open-icon"><i class="far fa-search"></i></span></button>
-                        </li> -->
-                    </ul>
-                </nav>
+              <a href="/" title="Home" rel="home" class="rhd-header-logo">
+                <img src="https://developers.redhat.com/themes/custom/rhdp/logo.svg" alt="Home">
+              </a>
+              <nav role="navigation" aria-labelledby="rhd-navigation-menu" class="rhd-navigation-menu" data-block-plugin-id="system_menu_block:rhd-navigation">
+                <h2 class="visually-hidden" id="rhd-navigation-menu">RHD Primary Navigation</h2>
+                <ul class="rhd-menu">
+                  {{ range $.Site.Taxonomies.categories.page }}
+                  <li class="menu-item rhd-header-link"><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+                  {{ end }}
+                  <!-- <li class="rhd-nav-search">
+                    <div class="rhd-search-wrapper">
+                      <form class="search-bar" accept-charset="utf-8" action="./search/" method="get" role="search" type="submit" data-drupal-form-fields="search_list_text">
+                        <input class="user-search" type="text" placeholder="Search" id="search_list_text" name="t" maxlength="128" required="">
+                        <button type="submit" id="search-button"><i class="far fa-search"></i></button>
+                      </form>
+                    </div>
+                    <button class="rhd-search-toggle"><span class="open-icon"><i class="far fa-search"></i></span></button>
+                  </li> -->
+                </ul>
+              </nav>
             </div>
             <!-- <div class="menu-toggle-wrapper">
-                <button class="menu-toggle">Menu<span class="icon"><i class="far fa-bars"></i></span></button>
+              <button class="menu-toggle">Menu<span class="icon"><i class="far fa-bars"></i></span></button>
             </div> -->
+          </div>
         </div>
-    </div>
-</header>
+      </header>

--- a/src/docs/themes/rhd-docs/layouts/shortcodes/code.html
+++ b/src/docs/themes/rhd-docs/layouts/shortcodes/code.html
@@ -1,8 +1,8 @@
 <div class="pf-l-grid">
-<pre class="pf-m-10-col pf-m-offset-1-col" style="max-height: 10em;">
-<code class="language-html">{{ string .Inner }}</code>
-</pre>
+  <pre class="pf-m-10-col pf-m-offset-1-col" style="max-height: 10em;">
+    <code class="language-html">{{ string .Inner }}</code>
+  </pre>
 </div>
 <div class="code-sample">
-{{ .Inner }}
+  {{ .Inner }}
 </div>

--- a/src/styles/rhd-theme/components/_cards.scss
+++ b/src/styles/rhd-theme/components/_cards.scss
@@ -80,6 +80,11 @@
   }
 }
 
+// Sets all cards the same height for all cards
+.rhd-m-full-height {
+  height: 100%;
+  justify-content: space-evenly;
+}
 
 .rhd-c-card__image {
   min-height: 130px;


### PR DESCRIPTION
Update the template layouts to use PatternFly Core, rather than PatternFly Elements.

Update various components to use proper PFCore component styling, rather than default browser styling (titles, lists, tables, etc).

Update the Home reference page, as it was broken, due to it's use of PatternFly Elements (which are no longer available).

- _a page was updated to remove merge conflict comments, outside of the scope of this work, in order for the build to work_

Fixes #123 