### PR TITLE
Bump PatternFly Core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@fortawesome/pro-light-svg-icons": "5.8.1",
     "@fortawesome/pro-regular-svg-icons": "5.8.1",
     "@fortawesome/pro-solid-svg-icons": "5.8.2",
-    "@patternfly/patternfly": "2.21.5",
+    "@patternfly/patternfly": "2.31.6",
     "@patternfly/pfe-band": "1.0.0-prerelease.19",
     "@patternfly/pfe-card": "1.0.0-prerelease.19",
     "@patternfly/pfe-cta": "1.0.0-prerelease.19",


### PR DESCRIPTION
Bump the PatternFly Core version from `2.21.5` to `2.31.6`. As part of this version bump, the following improvements are available:

- Dark themes for Navigation and Page components
- Variations to Form Labels when padding differs
- Add toggle for split-buttons
- New Loading indicator (runs at 60 FPS)
- Primary toggle dropdown variation
- New left-aligned footer button variations
- Support for custom toggle icons
- a11y updates and improvements