### PR TITLE
[#188] Update package.json and tsconfig.prod.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Front-end assets and documentation for Red Hat Developer site",
   "main": "index.js",
   "engines": {
-    "node": ">=10.16.2"
+    "node": ">=10.10.0"
   },
   "scripts": {
     "start": "npm run scripts",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -5,7 +5,6 @@
         "moduleResolution": "node",
         "target": "es5",
         "noImplicitAny": false,
-        "allowUmdGlobalAccess": true,
         "allowSyntheticDefaultImports": true,
         "sourceMap": false,
         "removeComments": true,
@@ -31,6 +30,6 @@
         }
     },
     "include": [
-        "src/scripts/@rhd/**/*.ts"       
+        "src/scripts/@rhd/**/*.ts"
     ]
 }


### PR DESCRIPTION
The update to package.json sets the required version of node to 10.10.0. This is the highest version we can support in RHEL 7 environments as it is the latest version offered by Software Collection Libraries. This is a requirement due to the
way we're currently integrating rhd-frontend with Drupal.

The update to tsconfig.prod.json removes the compiler option 'allowUmdGlobalAccess' as this was only introduced in Typescript 3.5 and this project currently does not support that.

Closes #188 