### PR TITLE
Adds the code snippet component

### DIFF
--- a/src/data/components/code-snippet/context/base/default.toml
+++ b/src/data/components/code-snippet/context/base/default.toml
@@ -1,0 +1,5 @@
+templates = ["""
+  <pre><code>oc new-project knativetutorial
+oc adm policy add-scc-to-user privileged -z default
+oc adm policy add-scc-to-user anyuid -z default</code></pre>
+"""]

--- a/src/data/components/code-snippet/context/base/details.toml
+++ b/src/data/components/code-snippet/context/base/details.toml
@@ -1,0 +1,1 @@
+name = "Code snippet"

--- a/src/data/components/code-snippet/variants.toml
+++ b/src/data/components/code-snippet/variants.toml
@@ -1,0 +1,4 @@
+[[variant]]
+id = "default"
+name = "Code snippet"
+order = 1

--- a/src/docs/content/components/code-snippet.md
+++ b/src/docs/content/components/code-snippet.md
@@ -1,0 +1,12 @@
+---
+title: "Code snippet"
+date: 2019-09-11T09:44:23-07:00
+draft: false
+type: component
+tags: ["component"]
+weight: 99
+description: "Displays formatted code snippets"
+component: "code-snippet"
+scripts: []
+---
+

--- a/src/styles/rhd.scss
+++ b/src/styles/rhd.scss
@@ -332,7 +332,8 @@ samp {
 }
 
 pre {
-  padding: 10px;
+  margin: 8px 0;
+  padding: 8px;
   background: #f9f9f9;
   border: 1px solid #d5d5d5;
   border-radius: 0;
@@ -350,6 +351,11 @@ code {
   background-color: #f9f9f9;
   font-weight: normal;
   color: #0a0a0a;
+}
+
+pre code {
+  padding: 0;
+  border: none;
 }
 
 .content-type-label {


### PR DESCRIPTION
#### Example of component in FE repo

<img width="1643" alt="Screen Shot 2019-09-11 at 10 02 44 AM" src="https://user-images.githubusercontent.com/7155034/64718593-66118180-d47b-11e9-916e-c1373123ab49.png">

#### Example of component with margins and padding outlined
<img width="1647" alt="Screen Shot 2019-09-11 at 10 02 53 AM" src="https://user-images.githubusercontent.com/7155034/64718594-66118180-d47b-11e9-9b1c-77158cfda191.png">

#### Example of explicit margin and padding in inspector

<img width="344" alt="Screen Shot 2019-09-11 at 10 03 03 AM" src="https://user-images.githubusercontent.com/7155034/64718595-66118180-d47b-11e9-80a1-b7045c4d1ffa.png">

## Verification steps

* Ensure that implementation demonstrated here meets design requirements in Marvel: https://marvelapp.com/c6c454h/screen/60311375