### PR TITLE
Add component-specific code snippet styles

### DIFF
--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -11,6 +11,7 @@
 @import "components/buttons";
 @import "components/component_base";
 @import "components/cards";
+@import "components/code-snippet";
 @import "components/curated-links";
 @import "components/dynamic-list";
 @import "components/rich-text";

--- a/src/styles/rhd-theme/components/_code-snippet.scss
+++ b/src/styles/rhd-theme/components/_code-snippet.scss
@@ -1,0 +1,5 @@
+.assembly-type-code_snippet .hljs {
+  padding: 0;
+  background-color: #f9f9f9;
+  color: #0a0a0a;
+}


### PR DESCRIPTION
This adds a few styles for the code snippet assembly type that are
specific to the assembly type implementation i.e. not styles that solely
apply to the `<pre>` or `<code>` HTML elements. These styles are provided by
HighlightJS, and we need to override them to meet our design
requirements.