### PR TITLE
Publish gh pages only gh pages branch

### DIFF
--- a/publish_gh_pages.sh
+++ b/publish_gh_pages.sh
@@ -7,7 +7,7 @@ then
 fi
 
 command -v hugo >/dev/null 2>&1 || { echo >&2 "I require hugo but it's not available in the PATH. Aborting."; exit 1; }
-git config remote.faraway.url > /dev/null 2>&1 || { echo >&2 "I require an upstream remote for this repository to publish to gh-pages. Aborting."; exit 1;}
+git config remote.upstream.url > /dev/null 2>&1 || { echo >&2 "I require an upstream remote for this repository to publish to gh-pages. Aborting."; exit 1;}
 
 echo "Deleting old publication"
 rm -rf public

--- a/publish_gh_pages.sh
+++ b/publish_gh_pages.sh
@@ -7,6 +7,7 @@ then
 fi
 
 command -v hugo >/dev/null 2>&1 || { echo >&2 "I require hugo but it's not available in the PATH. Aborting."; exit 1; }
+git config remote.faraway.url > /dev/null 2>&1 || { echo >&2 "I require an upstream remote for this repository to publish to gh-pages. Aborting."; exit 1;}
 
 echo "Deleting old publication"
 rm -rf public
@@ -27,4 +28,4 @@ echo "Updating gh-pages branch"
 cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
 
 echo "Pushing to github"
-git push --all
+git push upstream gh-pages


### PR DESCRIPTION
This ensures that we only push to upstream/gh-pages with the `publish_gh_pages.sh` script. It also now verifies that an `upstream` remote exists prior to executing non-validation commands