### PR TITLE
Update link icon color

### DIFF
--- a/src/styles/rhd-theme/components/_buttons.scss
+++ b/src/styles/rhd-theme/components/_buttons.scss
@@ -34,21 +34,80 @@
 }
 
 .pf-c-button.pf-m-link {
+  color: var(--rhd-c-button--m-secondary--Color);
   background-color: transparent;
+  &:hover,
+  &:focus,
+  &.pf-m-active,
+  &.pf-m-focus {
+    color: var(--rhd-c-button--m-secondary--hover--Color);
+    & > .pf-c-button__icon > i,
+    & > .pf-c-button__icon > .svg-inline--fa {
+      color: var(--rhd-c-button--m-secondary--hover--Color) !important;
+    }
+  }
+  & > .pf-c-button__icon > i,
+  & > .pf-c-button__icon > .svg-inline--fa,
+  & > i,
+  & > .svg-inline--fa {
+    color: var(--rhd-c-button--m-secondary--Color) !important;
+    &:hover,
+    &:active,
+    &:focus,
+    &:visited {
+      color: var(--rhd-c-button--m-secondary--hover--Color) !important;
+    }
+  }
 }
 
-.pf-m-link--secondary {
+.pf-c-button.pf-m-link--secondary {
   @extend .pf-m-link;
   color: var(--rhd-c-button--m-tertiary--Color) !important;
+  &:hover,
+  &:focus,
+  &.pf-m-active,
+  &.pf-m-focus {
+    color: var(--rhd-c-button--m-tertiary--Color) !important;
+    & > .pf-c-button__icon > i,
+    & > .pf-c-button__icon > .svg-inline--fa {
+      color: var(--rhd-c-button--m-tertiary--Color) !important;
+    }
+  }
+  & > .pf-c-button__icon > i,
+  & > .pf-c-button__icon > .svg-inline--fa {
+    color: var(--rhd-c-button--m-tertiary--Color) !important;
+    &:hover,
+    &:active,
+    &:focus,
+    &:visited {
+      color: var(--rhd-c-button--m-tertiary--Color) !important;
+    }
+  }
 
   &-on-dark {
     color: var(--rhd-c-button--m-secondary-dark--Color);
-      &:hover,
-      &:focus,
-      &.pf-m-active,
-      &.pf-m-focus {
-        color: #9D9D9D;
+    &:hover,
+    &:focus,
+    &.pf-m-active,
+    &.pf-m-focus {
+      color: #9D9D9D;
+      & > .pf-c-button__icon > i,
+      & > .pf-c-button__icon > .svg-inline--fa {
+        color: #9D9D9D !important;
       }
+    }
+    & > .pf-c-button__icon > i,
+    & > .pf-c-button__icon > .svg-inline--fa,
+    & > i,
+    & > .svg-inline--fa {
+      color: var(--rhd-c-button--m-secondary-dark--Color) !important;
+      &:hover,
+      &:active,
+      &:focus,
+      &:visited {
+        color: #9D9D9D !important;
+      }
+    }
   }
 }
 
@@ -59,6 +118,20 @@
   &.pf-m-active,
   &.pf-m-focus {
     color: #2A99F1;
+    & > .pf-c-button__icon > i,
+    & > .pf-c-button__icon > .svg-inline--fa {
+      color: #2A99F1 !important;
+    }
+  }
+  & > .pf-c-button__icon > i,
+  & > .pf-c-button__icon > .svg-inline--fa {
+    color: #73BCF7;
+    &:hover,
+    &:active,
+    &:focus,
+    &:visited {
+      color: #2A99F1;
+    }
   }
 }
 

--- a/src/styles/rhd-theme/components/_cards.scss
+++ b/src/styles/rhd-theme/components/_cards.scss
@@ -45,8 +45,25 @@
 .rhd-m-link {
   color: #06c;
   text-decoration: none;
+  &:hover,
+  &:active,
+  &:focus,
   &:visited {
+    color: #004080;
+    & > i,
+    & > .svg-inline--fa {
+      color: #004080 !important;
+    }
+  }
+  & > i,
+  & > .svg-inline--fa {
     color: #06c;
+    &:hover,
+    &:active,
+    &:focus,
+    &:visited {
+      color: #004080;
+    }
   }
 }
 

--- a/src/styles/rhd-theme/components/_footer.scss
+++ b/src/styles/rhd-theme/components/_footer.scss
@@ -17,7 +17,7 @@
     grid-template-columns: repeat(4,1fr);
     grid-gap: 1.5rem;
   }
-  
+
   .rhd-menu > .menu-item.menu-item--expanded {
     list-style: none;
   }
@@ -91,6 +91,26 @@
       &:first-child { margin-left: 0; }
       a {
         font-size: 1.5rem;
+        &:hover,
+        &:active,
+        &:focus {
+          font-size: 1.5rem;
+          & > i,
+          & > .svg-inline--fa,
+          & > .svg-inline--fa > * {
+            color: #fff !important;
+          }
+        }
+        & > i,
+        & > .svg-inline--fa {
+          color: #fff !important;
+          &:hover,
+          &:active,
+          &:focus,
+          &:visited {
+            color: #fff !important;
+          }
+        }
       }
     }
   }
@@ -133,7 +153,7 @@
         grid-column-end: 3;
         img {
             width: 140px;
-        }  
+        }
     }
     &-legal {
         grid-column-start: 3;
@@ -171,12 +191,12 @@
             &:last-child:after {
               display: none;
             }
-        } 
+        }
     }
     &-summit-logo {
         grid-column-start: 11;
         grid-column-end: 12;
-        justify-self: end;  
+        justify-self: end;
     }
 }
 
@@ -203,7 +223,7 @@
         position: relative;
       }
     }
-    .menu-item--expanded .section-toggle:before { 
+    .menu-item--expanded .section-toggle:before {
       content: "\203A";
       display: inline-block;
       top: 10px;
@@ -213,7 +233,7 @@
       -ms-transform: rotate(90deg);
       transform: rotate(90deg);
     }
-    .menu-item--expanded.collapsed .section-toggle:before { 
+    .menu-item--expanded.collapsed .section-toggle:before {
       content: "\203A";
       display: inline-block;
       top: 2px;
@@ -258,7 +278,7 @@
 
   .rh-c-universal-footer {
     padding: 1em;
-  
+
     &-legal {
       margin-left: 0;
     }


### PR DESCRIPTION
Update the link icon color to correspond to the neighboring text color. A previous commit updated the icon color to be grey, overwriting the inherited `pf-m-link` color from the parent element.

![Link1](https://user-images.githubusercontent.com/4032718/64879341-c3e0cd80-d623-11e9-930d-3e3b9fd87549.png)
![Link2](https://user-images.githubusercontent.com/4032718/64879342-c4796400-d623-11e9-9062-f94ca4b2944d.png)
![Link3](https://user-images.githubusercontent.com/4032718/64879343-c4796400-d623-11e9-92e8-c995d32b13d7.png)
