### PR TITLE
Only push gh-pages branch in sh scripts

### DIFF
--- a/publish_gh_pages.sh
+++ b/publish_gh_pages.sh
@@ -26,5 +26,5 @@ hugo
 echo "Updating gh-pages branch"
 cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
 
-echo "Pushing to github"
-git push --all
+echo "Pushing to gh-pages branch to upstream remote"
+git push upstream gh-pages

--- a/review_gh_pages.sh
+++ b/review_gh_pages.sh
@@ -27,4 +27,4 @@ echo "Updating gh-pages branch"
 cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
 
 echo "Pushing gh-pages branch to upstream remote"
-git push upstream gh-pags
+git push upstream gh-pages

--- a/review_gh_pages.sh
+++ b/review_gh_pages.sh
@@ -26,5 +26,5 @@ hugo --environment review
 echo "Updating gh-pages branch"
 cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
 
-echo "Pushing to github"
-git push --all
+echo "Pushing gh-pages branch to upstream remote"
+git push upstream gh-pags


### PR DESCRIPTION
This changes our .sh scripts so that they only push the gh-pages branch
to the upstream remote. Currently, the scripts git push --all, which I
feel is unexpected behavior and could possibly have undesirable
consequences.