### PR TITLE
Card Grid reference impl

### DIFF
--- a/src/data/components/card-grid/context/base/center-aligned.toml
+++ b/src/data/components/card-grid/context/base/center-aligned.toml
@@ -1,0 +1,84 @@
+templates = ["""
+<!-- The only difference between this (center-aligned.toml) implementation and 
+     the left-aligned.toml is the "center" class in the div.rhd-c-card-grid line. Everything
+     else should be the same. -->
+<div class="rhd-c-card-grid pf-c-content center">
+  <h2 class="pf-c-title pf-m-lg">Title for Assembly with Card Grid</h2>
+  <div class="pf-l-flex rhd-c-card-grid__wrapper">
+    <!-- ======== CARD COMPONENTS START HERE ========= -->
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="far fa-file-code"></i>
+        Cheat sheet
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image">Cheat sheet title that can go to two lines only and then must truncate after it passes two lines.</h3>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">Author Name & Author Name</div>
+        </div>
+        <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/kubernetes-cheat-sheet-cover.png?itok=io1KFs4d" class="rhd-c-card__image-body"/>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--cta">
+            <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="far fa-file-code"></i>
+        Cheat sheet
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image">Cheat sheet title that can go to two lines only and then must truncate after it passes two lines.</h3>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">Author Name & Author Name</div>
+        </div>
+        <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/kubernetes-cheat-sheet-cover.png?itok=io1KFs4d" class="rhd-c-card__image-body"/>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--cta">
+            <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="far fa-file-code"></i>
+        Cheat sheet
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image">Cheat sheet title that can go to two lines only and then must truncate after it passes two lines.</h3>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">Author Name & Author Name</div>
+        </div>
+        <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/kubernetes-cheat-sheet-cover.png?itok=io1KFs4d" class="rhd-c-card__image-body"/>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--cta">
+            <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="far fa-file-code"></i>
+        Cheat sheet
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image">Cheat sheet title that can go to two lines only and then must truncate after it passes two lines.</h3>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">Author Name & Author Name</div>
+        </div>
+        <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/kubernetes-cheat-sheet-cover.png?itok=io1KFs4d" class="rhd-c-card__image-body"/>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--cta">
+            <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- ======== END OF CARD COMPONENTS ========= -->
+  </div>
+</div>
+"""]

--- a/src/data/components/card-grid/context/base/center-aligned.toml
+++ b/src/data/components/card-grid/context/base/center-aligned.toml
@@ -2,8 +2,10 @@ templates = ["""
 <!-- The only difference between this (center-aligned.toml) implementation and 
      the left-aligned.toml is the "center" class in the div.rhd-c-card-grid line. Everything
      else should be the same. -->
-<div class="rhd-c-card-grid pf-c-content center">
-  <h2 class="pf-c-title pf-m-lg">Title for Assembly with Card Grid</h2>
+<div class="component rhd-c-card-grid pf-c-content center">
+  <div class="pf-l-flex">
+    <h2 class="pf-c-title pf-m-lg">Title for Assembly with Card Grid</h2>
+  </div>
   <div class="pf-l-flex rhd-c-card-grid__wrapper">
     <!-- ======== CARD COMPONENTS START HERE ========= -->
     <div class="pf-c-card rhd-c-card">

--- a/src/data/components/card-grid/context/base/details.toml
+++ b/src/data/components/card-grid/context/base/details.toml
@@ -1,0 +1,1 @@
+name = "DEFAULT CONTEXT"

--- a/src/data/components/card-grid/context/base/left-aligned.toml
+++ b/src/data/components/card-grid/context/base/left-aligned.toml
@@ -1,6 +1,8 @@
 templates = ["""
-<div class="rhd-c-card-grid pf-c-content">
-  <h2 class="pf-c-title pf-m-lg">Title for Assembly with Card Grid</h2>
+<div class="component rhd-c-card-grid pf-c-content">
+  <div class="pf-l-flex">
+    <h2 class="pf-c-title pf-m-lg">Title for Assembly with Card Grid</h2>
+  </div>
   <div class="pf-l-flex rhd-c-card-grid__wrapper">
     <!-- ======== CARD COMPONENTS START HERE ========= -->
     <div class="pf-c-card rhd-c-card">

--- a/src/data/components/card-grid/context/base/left-aligned.toml
+++ b/src/data/components/card-grid/context/base/left-aligned.toml
@@ -1,0 +1,81 @@
+templates = ["""
+<div class="rhd-c-card-grid pf-c-content">
+  <h2 class="pf-c-title pf-m-lg">Title for Assembly with Card Grid</h2>
+  <div class="pf-l-flex rhd-c-card-grid__wrapper">
+    <!-- ======== CARD COMPONENTS START HERE ========= -->
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="fas fa-newspaper"></i>
+        Quickstart
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+        <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. Must truncate after 3 lines.</p>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">
+            <a href="#" class="rhd-m-link">Author Name</a>
+          </div>
+          <div class="rhd-c-comment">
+            <i class="fas fa-comment"></i> 2
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="fas fa-newspaper"></i>
+        Quickstart
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+        <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. Must truncate after 3 lines.</p>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">
+            <a href="#" class="rhd-m-link">Author Name</a>
+          </div>
+          <div class="rhd-c-comment">
+            <i class="fas fa-comment"></i> 2
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="fas fa-newspaper"></i>
+        Quickstart
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+        <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. Must truncate after 3 lines.</p>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">
+            <a href="#" class="rhd-m-link">Author Name</a>
+          </div>
+          <div class="rhd-c-comment">
+            <i class="fas fa-comment"></i> 2
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="fas fa-newspaper"></i>
+        Quickstart
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+        <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. Must truncate after 3 lines.</p>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">
+            <a href="#" class="rhd-m-link">Author Name</a>
+          </div>
+          <div class="rhd-c-comment">
+            <i class="fas fa-comment"></i> 2
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- ======== END OF CARD COMPONENTS ========= -->
+  </div>
+</div>
+"""]

--- a/src/data/components/card-grid/variants.toml
+++ b/src/data/components/card-grid/variants.toml
@@ -1,0 +1,9 @@
+[[variant]]
+id = "left-aligned"
+name = "Left Aligned"
+order = 1
+
+[[variant]]
+id = "center-aligned"
+name = "Center Aligned"
+order = 2

--- a/src/docs/content/components/card-grid.md
+++ b/src/docs/content/components/card-grid.md
@@ -1,0 +1,14 @@
+---
+title: "Card Grid Component"
+date: 2018-07-22T11:15:00-04:00
+description: ""
+draft: false
+tags: ["component"]
+weight: 99
+component: "card-grid"
+scripts: [""]
+---
+
+__CARD GRID COMPONENT__
+
+Sample Variations

--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -29,6 +29,7 @@
 @import "components/footer";
 @import "components/jump-to-nav";
 @import "components/featured-resources";
+@import "components/card-grid";
 
 pfe-cta {
   border-radius: 3px;

--- a/src/styles/rhd-theme/components/_card-grid.scss
+++ b/src/styles/rhd-theme/components/_card-grid.scss
@@ -1,4 +1,10 @@
 .rhd-c-card-grid {
+    @extend .pf-u-pt-lg;
+    @extend .pf-u-pb-lg;
+
+    h2.pf-c-title {
+        @extend .pf-u-w-100;
+    }
     .rhd-c-card {
         --pf-l-flex--spacer: var(--pf-l-flex--spacer--none);
         margin-bottom: var(--pf-l-flex--spacer--lg);

--- a/src/styles/rhd-theme/components/_card-grid.scss
+++ b/src/styles/rhd-theme/components/_card-grid.scss
@@ -1,0 +1,29 @@
+.rhd-c-card-grid {
+    .rhd-c-card {
+        --pf-l-flex--spacer: var(--pf-l-flex--spacer--none);
+        margin-bottom: var(--pf-l-flex--spacer--lg);
+
+        &:last-of-type {
+            margin-right: var(--pf-l-flex--spacer--none);
+        }
+
+        @media screen and (min-width: $pf-global--breakpoint--md) {
+            max-width: 285px;
+            --pf-l-flex--spacer: var(--pf-l-flex--spacer--lg);
+        }
+    }
+}
+
+.rhd-c-card-grid.center {
+    h2.pf-c-title {
+        text-align: center;
+    }
+
+    .rhd-c-card-grid__wrapper {
+        @extend .pf-m-justify-content-center;
+    }
+
+    .rhd-c-card:last-of-type {
+        margin-right: var(--pf-l-flex--spacer--lg);
+    }
+}


### PR DESCRIPTION
Added a reference implementation for assemblies needing a grid for cards.

This implementation includes the default, left-aligned grid shown below:
![image](https://user-images.githubusercontent.com/8727648/65010585-9454ee00-d8cd-11e9-8e4b-8c551b21157a.png)

And the center-aligned visual style which is the exact same implementation, with the distinction that it adds the class `center` on [line 5 of center-aligned.toml](https://github.com/redhat-developer/rhd-frontend/pull/208/files#diff-e626756a93e5a47e4935a4690c3cc0e4R5). Without that CSS class, the grid will default to being left aligned.
![image](https://user-images.githubusercontent.com/8727648/65010606-a8005480-d8cd-11e9-8255-f014f1e1a3e3.png)

Both grids default to two cards per row displayed on tablet, and a single card per row displayed on mobile.

Mobile views:
Left aligned --
![image](https://user-images.githubusercontent.com/8727648/65010891-a1bea800-d8ce-11e9-8662-d8773b257f96.png)

Center aligned --
![image](https://user-images.githubusercontent.com/8727648/65010899-a97e4c80-d8ce-11e9-9bca-24fe36cdc25e.png)


