### PR TITLE
Dynamic Content List with Disqus

### DIFF
--- a/src/data/components/comment-list-card/context/base/default.toml
+++ b/src/data/components/comment-list-card/context/base/default.toml
@@ -1,0 +1,39 @@
+templates = ["""
+<div class="pf-c-card rhd-c-card comment-list">
+  <div class="rhd-c-card-content">
+    <h3 class="rhd-c-card__title">Latest Comments</h3>
+    <div class="rhd-c-card__body">
+      <!-- Start of comment item -->
+      <div class="comment-list__item">
+        <h3 class="comment-list__item-title">10 tips for reviewing code you don’t like</h3>
+        <p class="comment-list__item-content">“I am in a unique situation at work where I have 20+ years of experience developing our software but with an old archaic programming language. My coworkers have rewritten most...”</p>
+        <small class="comment-list__item-date">July 18, 2019</small>
+        <div class="comment-list__item-cta">
+          <a href="">Reply  <i class="fas fa-arrow-right"></i></a>
+        </div>
+      </div>
+      <!-- End of comment item -->
+      <!-- Start of comment item -->
+      <div class="comment-list__item">
+        <h3 class="comment-list__item-title">10 tips for reviewing code you don’t like</h3>
+        <p class="comment-list__item-content">“I am in a unique situation at work where I have 20+ years of experience developing our software but with an old archaic programming language. My coworkers have rewritten most...”</p>
+        <small class="comment-list__item-date">July 18, 2019</small>
+        <div class="comment-list__item-cta">
+          <a href="">Reply  <i class="fas fa-arrow-right"></i></a>
+        </div>
+      </div>
+      <!-- End of comment item -->
+      <!-- Start of comment item -->
+      <div class="comment-list__item">
+        <h3 class="comment-list__item-title">10 tips for reviewing code you don’t like</h3>
+        <p class="comment-list__item-content">“I am in a unique situation at work where I have 20+ years of experience developing our software but with an old archaic programming language. My coworkers have rewritten most...”</p>
+        <small class="comment-list__item-date">July 18, 2019</small>
+        <div class="comment-list__item-cta">
+          <a href="">Reply  <i class="fas fa-arrow-right"></i></a>
+        </div>
+      </div> 
+      <!-- End of comment item -->
+    </div>
+  </div>
+</div>
+"""]

--- a/src/data/components/comment-list-card/context/base/details.toml
+++ b/src/data/components/comment-list-card/context/base/details.toml
@@ -1,0 +1,1 @@
+name = "DEFAULT CONTEXT"

--- a/src/data/components/comment-list-card/variants.toml
+++ b/src/data/components/comment-list-card/variants.toml
@@ -1,0 +1,4 @@
+[[variant]]
+id = "default"
+name = "Default Variant"
+order = 1

--- a/src/data/components/dynamic-content-list/context/base/default.toml
+++ b/src/data/components/dynamic-content-list/context/base/default.toml
@@ -1,0 +1,90 @@
+templates = ["""
+<div class="component pf-c-content rhd-c-dynamic-content-list">
+    <div class="pf-l-grid pf-m-gutter">
+      <h2 class="pf-c-title pf-m-3xl">Assembly Title</h2>
+      <!-- Start of dynamic-content-list content container -->
+      <div class="pf-l-grid__item pf-m-12-col pf-m-8-col-on-md">
+        <!-- Start of dynamic-content-list item -->
+        <div class="pf-l-grid pf-m-gutter rhd-c-dynamic-content-list__item">
+          <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+            <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/ae1324f59d12680a2a063c02367db366.png">
+          </div>
+          <div class="pf-l-grid__item pf-m-12-col pf-m-8-col-on-md">
+            <h3 class="rhd-c-dynamic-content-list__item-title"><a href="">Lorem Ipsum Dolar Saweet</a></h3>
+            <small class="pf-u-mt-xs pf-u-mb-xs">July 12, 2019</small>
+            <p>Aliqua cillum aliqua sunt nostrud enim deserunt ullamco aute exercitation. Mollit mollit elit quis tempor ad. Lorem reprehenderit consequat excepteur ex. Exercitation incididunt veniam ex eiusmod deserunt duis est amet. Enim cupidatat laborum nulla officia mollit.</p>
+          </div>
+        </div>
+        <!-- End of dynamic-content-list item -->
+        <!-- Start of dynamic-content-list item -->
+        <div class="pf-l-grid pf-m-gutter rhd-c-dynamic-content-list__item">
+          <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+            <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/59be861947c9331a09718d6512c0416e.png">
+          </div>
+          <div class="pf-l-grid__item pf-m-8-col">
+            <h3 class="rhd-c-dynamic-content-list__item-title"><a href="">Lorem Ipsum Dolar Saweet</a></h3>
+            <small>July 12, 2019</small>
+            <p>Aliqua cillum aliqua sunt nostrud enim deserunt ullamco aute exercitation. Mollit mollit elit quis tempor ad. Lorem reprehenderit consequat excepteur ex. Exercitation incididunt veniam ex eiusmod deserunt duis est amet. Enim cupidatat laborum nulla officia mollit.</p>
+          </div>
+        </div>
+        <!-- End of dynamic-content-list item -->
+        <!-- Start of dynamic-content-list item -->
+        <div class="pf-l-grid pf-m-gutter rhd-c-dynamic-content-list__item">
+          <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+            <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/6e27466d0161fa3f81a69737aec7f9c6.jpg">
+          </div>
+          <div class="pf-l-grid__item pf-m-8-col">
+            <h3 class="rhd-c-dynamic-content-list__item-title"><a href="">Lorem Ipsum Dolar Saweet</a></h3>
+            <small>July 12, 2019</small>
+            <p>Aliqua cillum aliqua sunt nostrud enim deserunt ullamco aute exercitation. Mollit mollit elit quis tempor ad. Lorem reprehenderit consequat excepteur ex. Exercitation incididunt veniam ex eiusmod deserunt duis est amet. Enim cupidatat laborum nulla officia mollit.</p>
+          </div>
+        </div>
+        <!-- End of dynamic-content-list item -->
+      </div>
+      <!-- End of dynamic-content-list content container -->
+
+      <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+        <!-- Start of Comment List Card Component -->
+        <div class="pf-c-card rhd-c-card comment-list">
+          <div class="rhd-c-card-content">
+            <h3 class="rhd-c-card__title">Latest Comments</h3>
+            <div class="rhd-c-card__body">
+              <!-- Start of comment item -->
+              <div class="comment-list__item">
+                <h3 class="comment-list__item-title">10 tips for reviewing code you don’t like</h3>
+                <p class="comment-list__item-content">“I am in a unique situation at work where I have 20+ years of experience developing our software but with an old archaic programming language. My coworkers have rewritten most...”</p>
+                <small class="comment-list__item-date">July 18, 2019</small>
+                <div class="comment-list__item-cta">
+                  <a href="">Reply  <i class="fas fa-arrow-right"></i></a>
+                </div>
+              </div>
+              <!-- End of comment item -->
+              <!-- Start of comment item -->
+              <div class="comment-list__item">
+                <h3 class="comment-list__item-title">10 tips for reviewing code you don’t like</h3>
+                <p class="comment-list__item-content">“I am in a unique situation at work where I have 20+ years of experience developing our software but with an old archaic programming language. My coworkers have rewritten most...”</p>
+                <small class="comment-list__item-date">July 18, 2019</small>
+                <div class="comment-list__item-cta">
+                  <a href="">Reply  <i class="fas fa-arrow-right"></i></a>
+                </div>
+              </div>
+              <!-- End of comment item -->
+              <!-- Start of comment item -->
+              <div class="comment-list__item">
+                <h3 class="comment-list__item-title">10 tips for reviewing code you don’t like</h3>
+                <p class="comment-list__item-content">“I am in a unique situation at work where I have 20+ years of experience developing our software but with an old archaic programming language. My coworkers have rewritten most...”</p>
+                <small class="comment-list__item-date">July 18, 2019</small>
+                <div class="comment-list__item-cta">
+                  <a href="">Reply  <i class="fas fa-arrow-right"></i></a>
+                </div>
+              </div> 
+              <!-- End of comment item -->
+            </div>
+          </div>
+        </div>
+        <!-- End of Comment List Card Component -->
+      </div>
+      <!-- End of dynamic-content-list Disqus container -->
+    </div>
+</div>
+"""]

--- a/src/data/components/dynamic-content-list/context/base/details.toml
+++ b/src/data/components/dynamic-content-list/context/base/details.toml
@@ -1,0 +1,1 @@
+name = "DEFAULT CONTEXT"

--- a/src/data/components/dynamic-content-list/context/base/no-padding-bottom.toml
+++ b/src/data/components/dynamic-content-list/context/base/no-padding-bottom.toml
@@ -1,0 +1,42 @@
+templates = ["""
+<div class="component pf-c-content rhd-c-dynamic-content-list no-padding-bottom">
+    <div class="pf-l-grid pf-m-gutter">
+      <h2 class="pf-c-title pf-m-3xl">Assembly Title</h2>
+      <!-- Start of dynamic-content-list content container -->
+      <div class="pf-l-grid__item pf-m-12-col pf-m-8-col-on-md">
+        <!-- Start of dynamic-content-list item -->
+        <div class="pf-l-grid pf-m-gutter rhd-c-dynamic-content-list__item">
+          <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+            <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/e684ea8849af25532d2f2c5ad1c6dab4.png">
+          </div>
+          <div class="pf-l-grid__item pf-m-12-col pf-m-8-col-on-md">
+            <h3 class="rhd-c-dynamic-content-list__item-title"><a href="">Lorem Ipsum Dolar Saweet</a></h3>
+            <small class="pf-u-mt-xs pf-u-mb-xs">July 12, 2019</small>
+            <p>Aliqua cillum aliqua sunt nostrud enim deserunt ullamco aute exercitation. Mollit mollit elit quis tempor ad. Lorem reprehenderit consequat excepteur ex. Exercitation incididunt veniam ex eiusmod deserunt duis est amet. Enim cupidatat laborum nulla officia mollit.</p>
+          </div>
+        </div>
+        <!-- End of dynamic-content-list item -->
+        
+      </div>
+      <!-- End of dynamic-content-list content container -->
+
+      <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md ">
+        <div class="pf-c-card rhd-c-card comment-list">
+          <div class="rhd-c-card-content">
+            <h3 class="rhd-c-card__title">Latest Comments</h3>
+            <div class="rhd-c-card__body">
+              <div class="comment-list__item">
+                <h3 class="comment-list__item-title">10 tips for reviewing code you don’t like</h3>
+                <p class="comment-list__item-content">“I am in a unique situation at work where I have 20+ years of experience developing our software but with an old archaic programming language. My coworkers have rewritten most...”</p>
+                <small class="comment-list__item-date">July 18, 2019</small>
+                <div class="comment-list__item-cta">
+                  <a href="">Reply  <i class="fas fa-arrow-right"></i></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+</div>
+"""]

--- a/src/data/components/dynamic-content-list/context/base/no-padding-top.toml
+++ b/src/data/components/dynamic-content-list/context/base/no-padding-top.toml
@@ -1,0 +1,42 @@
+templates = ["""
+<div class="component pf-c-content rhd-c-dynamic-content-list no-padding-top">
+    <div class="pf-l-grid pf-m-gutter">
+      <h2 class="pf-c-title pf-m-3xl">Assembly Title</h2>
+      <!-- Start of dynamic-content-list content container -->
+      <div class="pf-l-grid__item pf-m-12-col pf-m-8-col-on-md">
+        <!-- Start of dynamic-content-list item -->
+        <div class="pf-l-grid pf-m-gutter rhd-c-dynamic-content-list__item">
+          <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+            <img src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/e684ea8849af25532d2f2c5ad1c6dab4.png">
+          </div>
+          <div class="pf-l-grid__item pf-m-12-col pf-m-8-col-on-md">
+            <h3 class="rhd-c-dynamic-content-list__item-title"><a href="">Lorem Ipsum Dolar Saweet</a></h3>
+            <small class="pf-u-mt-xs pf-u-mb-xs">July 12, 2019</small>
+            <p>Aliqua cillum aliqua sunt nostrud enim deserunt ullamco aute exercitation. Mollit mollit elit quis tempor ad. Lorem reprehenderit consequat excepteur ex. Exercitation incididunt veniam ex eiusmod deserunt duis est amet. Enim cupidatat laborum nulla officia mollit.</p>
+          </div>
+        </div>
+        <!-- End of dynamic-content-list item -->
+        
+      </div>
+      <!-- End of dynamic-content-list content container -->
+
+      <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md ">
+        <div class="pf-c-card rhd-c-card comment-list">
+          <div class="rhd-c-card-content">
+            <h3 class="rhd-c-card__title">Latest Comments</h3>
+            <div class="rhd-c-card__body">
+              <div class="comment-list__item">
+                <h3 class="comment-list__item-title">10 tips for reviewing code you don’t like</h3>
+                <p class="comment-list__item-content">“I am in a unique situation at work where I have 20+ years of experience developing our software but with an old archaic programming language. My coworkers have rewritten most...”</p>
+                <small class="comment-list__item-date">July 18, 2019</small>
+                <div class="comment-list__item-cta">
+                  <a href="">Reply  <i class="fas fa-arrow-right"></i></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+</div>
+"""]

--- a/src/data/components/dynamic-content-list/variants.toml
+++ b/src/data/components/dynamic-content-list/variants.toml
@@ -1,0 +1,14 @@
+[[variant]]
+id = "default"
+name = "Default Variant"
+order = 1
+
+[[variant]]
+id = "no-padding-top"
+name = "No Padding Top Variant"
+order = 2
+
+[[variant]]
+id = "no-padding-bottom"
+name = "No Padding Bottom Variant"
+order = 3

--- a/src/docs/content/components/comment-list-card.md
+++ b/src/docs/content/components/comment-list-card.md
@@ -1,0 +1,15 @@
+---
+title: "Comment List Card Component"
+date: 2018-07-22T11:15:00-04:00
+description: ""
+draft: false
+tags: ["component"]
+categories: ["component"]
+weight: 99
+component: "comment-list-card"
+scripts: [""]
+---
+
+__TEMPLATE COMPONENT__
+
+Sample Variations

--- a/src/docs/content/components/dynamic-content-list.md
+++ b/src/docs/content/components/dynamic-content-list.md
@@ -1,0 +1,15 @@
+---
+title: "Dynamic Content List with Comments"
+date: 2018-07-22T11:15:00-04:00
+description: ""
+draft: false
+tags: ["component"]
+categories: ["component"]
+weight: 99
+component: "dynamic-content-list"
+scripts: [""]
+---
+
+__DYNAMIC CONTENT LIST COMPONENT__
+
+Sample Variations

--- a/src/docs/content/components/dynamic-list.md
+++ b/src/docs/content/components/dynamic-list.md
@@ -1,5 +1,5 @@
 ---
-title: "Dynamic Content List"
+title: "Deprecated Dynamic Content List"
 date: 2019-08-15T14:30:10-04:00
 draft: false
 type: component

--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -31,6 +31,7 @@
 @import "components/featured-resources";
 @import "components/card-grid";
 @import "components/product-download-list";
+@import "components/dynamic-content-list";
 
 pfe-cta {
   border-radius: 3px;

--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -32,6 +32,7 @@
 @import "components/card-grid";
 @import "components/product-download-list";
 @import "components/dynamic-content-list";
+@import "components/comment-list-card";
 
 pfe-cta {
   border-radius: 3px;

--- a/src/styles/rhd-theme/components/_comment-list-card.scss
+++ b/src/styles/rhd-theme/components/_comment-list-card.scss
@@ -1,0 +1,45 @@
+.rhd-c-card.comment-list {
+  .rhd-c-card__title {
+    font-size: var(--pf-global--FontSize--xl) !important;
+    margin-bottom: var(--pf-global--spacer--md);
+  }
+}
+
+.comment-list__item {
+
+  &:not(:last-of-type) {
+    margin-bottom: var(--pf-global--spacer--md);
+  }
+
+  &-title {
+    margin-bottom: var(--pf-global--spacer--sm);
+    font-size: var(--pf-global--FontSize--lg);
+  }
+
+  &-content {
+    margin-bottom: var(--pf-global--spacer--sm) !important;
+  }
+
+  &-date {
+    color: var(--rhd-theme--color-text--subtle); // #72767b
+  }
+  &-cta {
+    display: block;
+    margin-top: var(--pf-global--spacer--md);
+  }
+
+  a {
+    color: #06c;
+    text-decoration: none;
+    &:hover,
+    &:active,
+    &:focus,
+    &:visited {
+      color: #004080;
+      & > i,
+      & > .svg-inline--fa {
+        color: #004080 !important;
+      }
+    }
+  }
+}

--- a/src/styles/rhd-theme/components/_dynamic-content-list.scss
+++ b/src/styles/rhd-theme/components/_dynamic-content-list.scss
@@ -1,0 +1,24 @@
+.rhd-c-dynamic-content-list {
+  @extend .pf-u-pt-lg;
+  @extend .pf-u-pb-lg;
+
+  h2 {
+    text-align: center;
+  }
+
+  &__item {
+    @extend .pf-u-pb-md;
+  }
+  
+  &__item-title {
+    @extend .pf-u-mb-0;
+  }
+
+  &.no-padding-top {
+    @extend .pf-u-pt-0;
+  }
+
+  &.no-padding-bottom {
+    @extend .pf-u-pb-0;
+  }
+}


### PR DESCRIPTION
Adds Dynamic Content List with Disqus with its two Visual Styles 'No Padding Top' and 'No Padding Bottom'.

To add the visual styles, the classes `no-padding-bottom` and / or `no-padding-top` should be added on the `<div class="component pf-c-content rhd-c-dynamic-content-list">` tag ( [line 2](https://github.com/redhat-developer/rhd-frontend/pull/213/files#diff-92ff1cab51b9b82d6cb99ceb66f01f3cR2) here).

Desktop:
![image](https://user-images.githubusercontent.com/8727648/65084989-2d394700-d96a-11e9-87d7-0ac8f47db4a2.png)

Mobile: 
![image](https://user-images.githubusercontent.com/8727648/65084993-32969180-d96a-11e9-97d4-50d9b1f70d46.png)

Closes #172 