### PR TITLE
Updates ebook card with image

### DIFF
--- a/src/data/components/card/context/ebooks/card_with_image.toml
+++ b/src/data/components/card/context/ebooks/card_with_image.toml
@@ -3,16 +3,16 @@ templates = ["""<div class="pf-c-card rhd-c-card">
           <i class="fas fa-book"></i>
           eBook
         </div>
-        <img src="https://images.pexels.com/photos/417173/pexels-photo-417173.jpeg?cs=srgb&dl=altitude-clouds-cold-417173.jpg&fm=jpg" class="rhd-c-card__image"/>
         <div class="rhd-c-card-content">
-          <h3 class="rhd-c-card__title">
-            eBook title that can go to two lines, but will then hide until hovered
+          <h3 class="rhd-c-card__title rhd-m-card-title__no-image">
+            eBook title that can go to two lines only and then must truncate after it passes two lines.
           </h3>
-          <div class="rhd-c-card__footer rhd-m-multi-author">
+          <div class="rhd-c-card__footer">
             <div class="rhd-c-card__footer--author">
               Author Name & Author Name
             </div>
           </div>
+          <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/cover-image/2019-04/istio-service-mesh-microservices.png" class="rhd-c-card__image-body"/>
           <div class="rhd-c-card__footer">
             <div class="rhd-c-card__footer--cta">
               <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>

--- a/src/docs/content/components/card-html.html
+++ b/src/docs/content/components/card-html.html
@@ -718,18 +718,18 @@ weight: 99
         <i class="fas fa-book"></i>
         eBook
       </div>
-      <img src="https://images.pexels.com/photos/417173/pexels-photo-417173.jpeg?cs=srgb&dl=altitude-clouds-cold-417173.jpg&fm=jpg" class="rhd-c-card__image"/>
       <div class="rhd-c-card-content">
-        <h3 class="rhd-c-card__title">
-          eBook title that can go to two lines, but will then hide until hovered
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image">
+          eBook title that can go to two lines only and then must truncate after it passes two lines.
         </h3>
-        <div class="rhd-c-card__footer rhd-m-multi-author">
+        <div class="rhd-c-card__footer">
           <div class="rhd-c-card__footer--author">
             Author Name & Author Name
           </div>
         </div>
+        <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/cover-image/2019-04/istio-service-mesh-microservices.png" class="rhd-c-card__image-body"/>
         <div class="rhd-c-card__footer">
-          <div class="rhd-c-card__footer--download">
+          <div class="rhd-c-card__footer--cta">
             <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
           </div>
         </div>


### PR DESCRIPTION
Updates eBook Card with Image card style/layout to match the Cheat Sheet Card with Image card style and layout.

![image](https://user-images.githubusercontent.com/8727648/65172246-e438cf80-da09-11e9-8cc6-7ddd0e965d84.png)


Closes #219  

cc: @gdoyle1 