### PR TITLE
Update Bonus Content Item for Lists

### DIFF
--- a/src/data/components/bonus-content-item/context/base/default.toml
+++ b/src/data/components/bonus-content-item/context/base/default.toml
@@ -1,26 +1,26 @@
 templates = ["""
-  <div class="pf-l-grid">
-    <div class="pf-l-grid__item pf-m-10-col">
-      <hr class="rhd-c-divider pf-u-mt-lg">
-      <div class="pf-l-grid pf-m-gutter">
-        <div class="pf-l-grid__item pf-m-1-col pf-u-display-flex pf-u-align-items-center rhd-c-avatar--container">
-          <img class="pf-c-avatar rhd-c-avatar" src="https://www.patternfly.org/assets/images/img_avatar.svg" alt="Content image">
-        </div>
-        <div class="pf-l-grid__item pf-m-6-col">
-          <div class="pf-l-flex pf-m-column">
-            <div class="pf-l-flex__item pf-u-display-inline-flex rhd-c-bonus-content-item">
-              <div class="rhd-c-bonus-content-item__image">
-                <i class="fas fa-code"></i>
+  <div class="rhd-l-bonus-content-item">
+    <div class="pf-l-grid rhd-l-bonus-content-item-grid">
+      <div class="pf-l-grid__item pf-m-10-col">
+        <div class="pf-l-grid pf-m-gutter">
+          <div class="pf-l-grid__item pf-m-1-col pf-u-display-flex pf-u-align-items-center rhd-c-avatar--container">
+            <img class="pf-c-avatar rhd-c-avatar" src="https://www.patternfly.org/assets/images/img_avatar.svg" alt="Content image">
+          </div>
+          <div class="pf-l-grid__item pf-m-6-col">
+            <div class="pf-l-flex pf-m-column">
+              <div class="pf-l-flex__item pf-u-display-inline-flex rhd-c-bonus-content-item">
+                <div class="rhd-c-bonus-content-item__image">
+                  <i class="fas fa-code"></i>
+                </div>
+                GitHub code
               </div>
-              GitHub code
-            </div>
-            <div class="pf-l-flex__item">
-              <p>This is the description of the bonus content item. It can be long or short, and still fit in the element.</p>
+              <div class="pf-l-flex__item">
+                <a href="#" class="pf-m-ink">This is the description of the bonus content item. It can be long or short, and still fit in the element.</a>
+              </div>
             </div>
           </div>
         </div>
       </div>
-      <hr class="rhd-c-divider pf-u-mb-lg">
     </div>
   </div>
 """]

--- a/src/data/components/bonus-content-item/context/base/default2.toml
+++ b/src/data/components/bonus-content-item/context/base/default2.toml
@@ -1,26 +1,26 @@
 templates = ["""
-  <div class="pf-l-grid">
-    <div class="pf-l-grid__item pf-m-10-col">
-      <hr class="rhd-c-divider pf-u-mt-lg">
-      <div class="pf-l-grid pf-m-gutter">
-        <div class="pf-l-grid__item pf-m-1-col pf-u-display-flex pf-u-align-items-center rhd-c-avatar--container">
-          <img class="pf-c-avatar rhd-c-avatar" src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" alt="Content image">
-        </div>
-        <div class="pf-l-grid__item pf-m-6-col">
-          <div class="pf-l-flex pf-m-column">
-            <div class="pf-l-flex__item pf-u-display-inline-flex rhd-c-bonus-content-item">
-              <div class="rhd-c-bonus-content-item__image">
-                <i class="fas fa-code"></i>
+  <div class="rhd-l-bonus-content-item">
+    <div class="pf-l-grid rhd-l-bonus-content-item-grid">
+      <div class="pf-l-grid__item pf-m-10-col">
+        <div class="pf-l-grid pf-m-gutter">
+          <div class="pf-l-grid__item pf-m-1-col pf-u-display-flex pf-u-align-items-center rhd-c-avatar--container">
+            <img class="pf-c-avatar rhd-c-avatar" src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" alt="Content image">
+          </div>
+          <div class="pf-l-grid__item pf-m-6-col">
+            <div class="pf-l-flex pf-m-column">
+              <div class="pf-l-flex__item pf-u-display-inline-flex rhd-c-bonus-content-item">
+                <div class="rhd-c-bonus-content-item__image">
+                  <i class="fas fa-code"></i>
+                </div>
+                GitHub code
               </div>
-              GitHub code
-            </div>
-            <div class="pf-l-flex__item">
-              <p>This is the description of the bonus content item. It can be long or short, and still fit in the element.</p>
+              <div class="pf-l-flex__item">
+                <a href="#" class="pf-m-ink">This is the description of the bonus content item. It can be long or short, and still fit in the element.</a>
+              </div>
             </div>
           </div>
         </div>
       </div>
-      <hr class="rhd-c-divider pf-u-mb-lg">
     </div>
   </div>
 """]

--- a/src/data/components/bonus-content-item/context/base/default3.toml
+++ b/src/data/components/bonus-content-item/context/base/default3.toml
@@ -1,0 +1,92 @@
+templates = ["""
+  <div class="rhd-l-bonus-content-item">
+    <div class="pf-l-grid rhd-l-bonus-content-item-grid">
+      <div class="pf-l-grid__item pf-m-10-col">
+        <div class="pf-l-grid pf-m-gutter">
+          <div class="pf-l-grid__item pf-m-1-col pf-u-display-flex pf-u-align-items-center rhd-c-avatar--container">
+            <img class="pf-c-avatar rhd-c-avatar" src="https://www.patternfly.org/assets/images/img_avatar.svg" alt="Content image">
+          </div>
+          <div class="pf-l-grid__item pf-m-6-col">
+            <div class="pf-l-flex pf-m-column">
+              <div class="pf-l-flex__item pf-u-display-inline-flex rhd-c-bonus-content-item">
+                <div class="rhd-c-bonus-content-item__image">
+                  <i class="fas fa-code"></i>
+                </div>
+                GitHub code
+              </div>
+              <div class="pf-l-flex__item">
+                <a href="#" class="pf-m-ink">This is the description of the bonus content item. It can be long or short, and still fit in the element.</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-l-grid rhd-l-bonus-content-item-grid">
+      <div class="pf-l-grid__item pf-m-10-col">
+        <div class="pf-l-grid pf-m-gutter">
+          <div class="pf-l-grid__item pf-m-1-col pf-u-display-flex pf-u-align-items-center rhd-c-avatar--container">
+            <img class="pf-c-avatar rhd-c-avatar" src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" alt="Content image">
+          </div>
+          <div class="pf-l-grid__item pf-m-6-col">
+            <div class="pf-l-flex pf-m-column">
+              <div class="pf-l-flex__item pf-u-display-inline-flex rhd-c-bonus-content-item">
+                <div class="rhd-c-bonus-content-item__image">
+                  <i class="fas fa-code"></i>
+                </div>
+                GitHub code
+              </div>
+              <div class="pf-l-flex__item">
+                <a href="#" class="pf-m-ink">This is the description of the bonus content item. It can be long or short, and still fit in the element.</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-l-grid rhd-l-bonus-content-item-grid">
+      <div class="pf-l-grid__item pf-m-10-col">
+        <div class="pf-l-grid pf-m-gutter">
+          <div class="pf-l-grid__item pf-m-1-col pf-u-display-flex pf-u-align-items-center rhd-c-avatar--container">
+            <img class="pf-c-avatar rhd-c-avatar" src="https://www.patternfly.org/assets/images/img_avatar.svg" alt="Content image">
+          </div>
+          <div class="pf-l-grid__item pf-m-6-col">
+            <div class="pf-l-flex pf-m-column">
+              <div class="pf-l-flex__item pf-u-display-inline-flex rhd-c-bonus-content-item">
+                <div class="rhd-c-bonus-content-item__image">
+                  <i class="fas fa-code"></i>
+                </div>
+                GitHub code
+              </div>
+              <div class="pf-l-flex__item">
+                <a href="#" class="pf-m-ink">This is the description of the bonus content item.</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pf-l-grid rhd-l-bonus-content-item-grid">
+      <div class="pf-l-grid__item pf-m-10-col">
+        <div class="pf-l-grid pf-m-gutter">
+          <div class="pf-l-grid__item pf-m-1-col pf-u-display-flex pf-u-align-items-center rhd-c-avatar--container">
+            <img class="pf-c-avatar rhd-c-avatar" src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" alt="Content image">
+          </div>
+          <div class="pf-l-grid__item pf-m-6-col">
+            <div class="pf-l-flex pf-m-column">
+              <div class="pf-l-flex__item pf-u-display-inline-flex rhd-c-bonus-content-item">
+                <div class="rhd-c-bonus-content-item__image">
+                  <i class="fas fa-code"></i>
+                </div>
+                GitHub code
+              </div>
+              <div class="pf-l-flex__item">
+                <a href="#" class="pf-m-ink">This is the description of the bonus content item. It can be long or short, and still fit in the element.</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+"""]

--- a/src/data/components/bonus-content-item/variants.toml
+++ b/src/data/components/bonus-content-item/variants.toml
@@ -7,3 +7,8 @@ order = 1
 id = "default2"
 name = "Bonus content item with image"
 order = 2
+
+[[variant]]
+id = "default3"
+name = "Bonus content items in a list"
+order = 3

--- a/src/styles/rhd-theme/components/_bonus-content-item.scss
+++ b/src/styles/rhd-theme/components/_bonus-content-item.scss
@@ -1,9 +1,27 @@
+.rhd-l-bonus-content-item {
+    margin-top: var(--pf-global--spacer--md);
+    margin-bottom: var(--pf-global--spacer--md);
+    border-top: 1px solid #d2d2d2;
+    border-bottom: 1px solid #d2d2d2;
+    .rhd-l-bonus-content-item-grid {
+      padding-bottom: var(--pf-global--spacer--md);
+    }  
+    .rhd-l-bonus-content-item-grid:first-of-type {
+      padding-top: var(--pf-global--spacer--md);
+    }
+    .rhd-l-bonus-content-item-grid:last-of-type {
+      padding-bottom: var(--pf-global--spacer--md);
+    }
+}
+
 .rhd-c-bonus-content-item {
+  margin-top: var(--pf-global--spacer--sm) !important;
+  margin-bottom: var(--pf-global--spacer--sm) !important;
   color: #72767B;
 }
 
 .rhd-c-bonus-content-item__image {
-  margin-right: 8px;
+  margin-right: var(--pf-global--spacer--sm);
   .pf-c-avatar {
     width: 85px;
     height: 85px;


### PR DESCRIPTION
Updates the Bonus Content Item component to automatically account for whether or not is is positioned in a list format. Padding/spacing and dividers will be dynamically adjusted depending on the number of items in a list (stacked).

Update the content of the item to be a link (per request of Gina), as well as adjusted the spacing between the title, body copy and vertical spacing in relation to the icon.

Closes https://github.com/redhat-developer/rhd-frontend/issues/211

![BonusContentItem](https://user-images.githubusercontent.com/4032718/65176870-9fba2d80-da23-11e9-96f5-da02619dcf77.png)
