### PR TITLE
Fix Card heights

### DIFF
--- a/src/styles/rhd-theme/components/_cards.scss
+++ b/src/styles/rhd-theme/components/_cards.scss
@@ -68,8 +68,6 @@
 }
 
 .rhd-c-card {
-  display: flex;
-  flex-flow: column;
   position: relative;
   padding: 0;
   hr {
@@ -90,6 +88,9 @@
 }
 
 .rhd-c-card-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
   padding: 0 var(--pf-global--spacer--md); // 0 16px
   margin-bottom: 0;
   & > .rhd-c-card__title:first-child {
@@ -202,6 +203,7 @@
 .rhd-c-card__body {
   font-family: "RedHatText", "Overpass", Overpass, Helvetica, Arial, sans-serif;
   font-size: var(--pf-global--FontSize--md) !important;
+  flex: 1 1 auto;
 }
 
 .rhd-c-card__footer {
@@ -285,4 +287,8 @@
 .rhd-c-card__footer:last-child {
   padding-bottom: var(--pf-global--spacer--md); // 16px
   margin-bottom: 0 !important; // override `::slotted(:not([slot]))` from PFElements
+}
+
+.pf-c-card {
+  height: 100%;
 }


### PR DESCRIPTION
Fix the Card components to automatically adjust their heights to match when presented in a group.

Fixes #217 

**Before**
![Card_before](https://user-images.githubusercontent.com/4032718/65260667-b8cee700-dad4-11e9-994a-8be7484e7b27.png)
![Home_before](https://user-images.githubusercontent.com/4032718/65260668-b9677d80-dad4-11e9-8924-afdc718700b1.png)
![Katacoda_before](https://user-images.githubusercontent.com/4032718/65260669-b9677d80-dad4-11e9-93bd-e7dc5dddd8f6.png)

**After**
![Card_after](https://user-images.githubusercontent.com/4032718/65260677-c08e8b80-dad4-11e9-8c82-2f53866d63fa.png)
![Home_after](https://user-images.githubusercontent.com/4032718/65260686-c2f0e580-dad4-11e9-8e09-48724df51963.png)
![Katacoda_after](https://user-images.githubusercontent.com/4032718/65260689-c5533f80-dad4-11e9-9c29-2acb9e3f9aa8.png)
