### PR TITLE
Add width: auto to Card image-body

### DIFF
--- a/src/styles/rhd-theme/components/_cards.scss
+++ b/src/styles/rhd-theme/components/_cards.scss
@@ -115,6 +115,7 @@
   display: flex;
   margin: 0 auto;
   max-height: 200px;
+  width: auto;
   padding: 0 48px var(--pf-global--spacer--md) 48px;
 }
 


### PR DESCRIPTION
This adds the style 'width: auto' to the content image in the Card
component. This will resolve an issue with aspect ratio that we are
experiencing in the Drupal implementation.