### PR TITLE
Adds header-link class

### DIFF
--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -61,3 +61,13 @@ pfe-cta {
   }
 
 }
+
+h1, h2, h3, h4, h5, h6 {
+  &.header-link > a {
+    color: inherit;
+    &:hover, &:focus, &:active {
+        color: inherit;
+        text-decoration: var(--pf-global--link--TextDecoration);
+    }
+  }
+}


### PR DESCRIPTION
Adds `header-link` class to " ...override the link color to inherit from the header. When hovered, the color should not change and it should have an underline."

To get these styles, simply add the class `header-link` to any h1, h2, h3, h4, h5, or h6 that contains a link.

For example:

```
<h3 class="header-link">
   <a href="#">Advanced Microservices Tracing with Jaeger</a>
</h3>
```

Closes #224 
( Duplicate of #231 )