### PR TITLE
Prod. Download List updates

### DIFF
--- a/src/data/components/product_download_list/context/base/default.toml
+++ b/src/data/components/product_download_list/context/base/default.toml
@@ -1,10 +1,10 @@
 templates = ["""
 <div class="component rhd-c-product-download-list pf-c-content">
     <div class="pf-l-grid pf-m-gutter pf-u-pt-lg pf-u-pb-lg">
-      <h2>All Downloads</h2>
+      <h3 class="pf-c-title pf-m-2xl">All Downloads</h3>
       <!-- Start of version row -->
       <div class="pf-l-grid__item pf-m-12-col">
-        <h3>2.0.0</h3>
+        <h3 class="pf-u-mb-md">2.0.0</h3>
         <!-- Start of version row item -->
         <div class="pf-l-grid pf-m-gutter product-version">
           <div class="pf-l-grid__item product-version__file-label-wrapper">
@@ -26,7 +26,7 @@ templates = ["""
 
       <!-- Start of version row -->
       <div class="pf-l-grid__item pf-m-12-col">
-        <h3>1.0.0</h3>
+        <h3 class="pf-u-mb-md">1.0.0</h3>
         <!-- Start of version row item -->
         <div class="pf-l-grid pf-m-gutter product-version">
           <div class="pf-l-grid__item product-version__file-label-wrapper">

--- a/src/styles/rhd-theme/components/_product-download-list.scss
+++ b/src/styles/rhd-theme/components/_product-download-list.scss
@@ -14,10 +14,10 @@
       @extend .pf-m-12-col;
       @extend .pf-m-3-col-on-lg;
       @extend .pf-m-2-col-on-xl;
-
       align-self: center;
-      padding-right: 20px;
+
       @media screen and (min-width: $pf-global--breakpoint--lg) {
+        padding-right: 20px;
         border-right: 1px solid #d5d5d5;
       }
     }


### PR DESCRIPTION
Fixes:
- ( #263 ) Assembly title needs to be H3 (24px)
- ( #263 ) Space between download list section title (for ex. 7.7) and list rows changes to 16px.
- ( #240 ) Removes right padding on `.product-version__file-label-wrapper` that is preventing the text from being centered in mobile viewports.

#263 Fixes:
![image](https://user-images.githubusercontent.com/8727648/65556020-6eda6c80-deeb-11e9-9e1e-66d4da4da2fc.png)

#240 Fixes:
![image](https://user-images.githubusercontent.com/8727648/65556031-7732a780-deeb-11e9-8d07-e552d8106f34.png)

Closes #263 
Closes #240 