### PR TITLE
Update Typography

### DIFF
--- a/src/docs/content/patterns/design/typography.md
+++ b/src/docs/content/patterns/design/typography.md
@@ -36,13 +36,17 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 <h1 class="pf-c-title pf-m-2xl pf-u-mt-lg">Header XL</h1>
 
-| Font family | Font size | Font weight | Line height | Class + Modifier |
-| --- | --- | --- | --- | --- |
-| RedHatDisplay | 36px | 400 | 46.8 | `.pf-c-title .pf-m-4xl` |
+| Font family | Font size | Font weight | Line height | Class + Modifier | Viewport size |
+| --- | --- | --- | --- | --- | --- |
+| RedHatDisplay | 40px | 300 | 53 | `.pf-c-title .pf-m-4xl` | `992px & above`
+| RedHatDisplay | 36px | 300 | 43.2 | `.pf-c-title .pf-m-4xl` | `991px to 480px`
+| RedHatDisplay | 32px | 300 | 38.4 | `.pf-c-title .pf-m-4xl` | `479px & below`
 
 {{< code >}}
 <h1 class="pf-c-title pf-m-4xl">"Design is where science and art break even."</h1>
 {{< /code >}}
+<h1 style="font-size: 36px; font-weight: 300; line-height: 43.2px;">"Design is where science and art break even."</h1>
+<h1 style="font-size: 32px; font-weight: 300; line-height: 38.4px;">"Design is where science and art break even."</h1>
 
 <hr class="rhd-c-divider">
 
@@ -50,10 +54,13 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 | Font family | Font size | Font weight | Line height | Class + Modifier or Element |
 | --- | --- | --- | --- | --- |
-| RedHatDisplay | 28px | 400 | 36.4 | `.pf-c-title .pf-m-3xl` |
+| RedHatDisplay | 32px | 400 | 42 | `.pf-c-title .pf-m-3xl` |
 
 {{< code >}}
 <h1 class="pf-c-title pf-m-3xl">"Design is where science and art break even."</h1>
+<div class="pf-c-content">
+  <h1>"Design is where science and art break even."</h1>
+</div>
 {{< /code >}}
 
 <hr class="rhd-c-divider">
@@ -62,12 +69,12 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 | Font family | Font size | Font weight | Line height | Class + Modifier or Element |
 | --- | --- | --- | --- | --- |
-| RedHatDisplay | 24px | 400 | 31.2 | `.pf-c-title .pf-m-2xl` or `<h1>` |
+| RedHatDisplay | 28px | 400 | 31.2 | `.pf-c-title .pf-m-2xl` or `<h2>` |
 
 {{< code >}}
-<h1 class="pf-c-title pf-m-2xl">"Design is where science and art break even."</h1>
+<h2 class="pf-c-title pf-m-2xl">"Design is where science and art break even."</h2>
 <div class="pf-c-content">
-  <h1>"Design is where science and art break even."</h1>
+  <h2>"Design is where science and art break even."</h2>
 </div>
 {{< /code >}}
 
@@ -77,12 +84,12 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 | Font family | Font size | Font weight | Line height | Class + Modifier or Element |
 | --- | --- | --- | --- | --- |
-| RedHatDisplay | 20px | 400 | 30 | `.pf-c-title .pf-m-xl` or `<h2>` |
+| RedHatDisplay | 20px | 400 | 30 | `.pf-c-title .pf-m-xl` or `<h3>` |
 
 {{< code >}}
-<h1 class="pf-c-title pf-m-xl">"Design is where science and art break even."</h1>
+<h3 class="pf-c-title pf-m-xl">"Design is where science and art break even."</h2>
 <div class="pf-c-content">
-  <h2>"Design is where science and art break even."</h2>
+  <h3>"Design is where science and art break even."</h3>
 </div>
 {{< /code >}}
 
@@ -92,12 +99,12 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 | Font family | Font size | Font weight | Line height | Class + Modifier or Element |
 | --- | --- | --- | --- | --- |
-| RedHatDisplay | 18px | 400 | 27 | `.pf-c-title .pf-m-lg` or `<h3>` |
+| RedHatDisplay | 18px | 400 | 27 | `.pf-c-title .pf-m-lg` or `<h4>` |
 
 {{< code >}}
-<h1 class="pf-c-title pf-m-lg">"Design is where science and art break even."</h1>
+<h4 class="pf-c-title pf-m-lg">"Design is where science and art break even."</h4>
 <div class="pf-c-content">
-  <h3>"Design is where science and art break even."</h3>
+  <h4>"Design is where science and art break even."</h4>
 </div>
 {{< /code >}}
 
@@ -112,12 +119,14 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 | RedHatText | 16px | 400 | 24 | <span style="color: #004080; text-decoration: underline;">#004080</span> | underline | `.pf-m-link` or `<a>` |
 
 <blockquote>
-  <p style="font-family: var(--pfe-theme--font-family); font-size: 16px; font-weight: 400;">This is standard text for the developer site</p>
-  <p style="font-family: var(--pfe-theme--font-family); font-size: 16px; font-weight: 400; color: #0066CC">This is link text for the developer site</p>
+  <p>This is standard text for the developer site</p>
+  <a>This is link text for the developer site</a>
   <p style="font-family: var(--pfe-theme--font-family); font-size: 16px; font-weight: 400; color: #004080; text-decoration: underline;">This is hovered link text for the developer site</p>
 </blockquote>
 
 <hr class="rhd-c-divider">
+
+<!-- Start Dark Section -->
 
 <h1 class="pf-c-title pf-m-3xl pf-u-mt-lg">Dark typography - on dark background</h1>
 <p>To properly use the dark theme, you can either place the content in a dark <code>< section ></code> with <code>class="pf-c-page__main-section pf-m-dark-100"</code>, wrap the content with <code>.pf-content</code> or add <code>pf-m-dark</code> to your element.</p>
@@ -132,14 +141,20 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 <h1 class="pf-c-title pf-m-2xl pf-u-mt-lg">Header XL</h1>
 
-| Font family | Font size | Font weight | Line height | Class + Modifier |
-| --- | --- | --- | --- | --- |
-| RedHatDisplay | 36px | 400 | 46.8 | `.pf-c-title .pf-m-4xl` |
+| Font family | Font size | Font weight | Line height | Class + Modifier | Viewport size |
+| --- | --- | --- | --- | --- | --- |
+| RedHatDisplay | 40px | 300 | 53 | `.pf-c-title .pf-m-4xl` | `992px & above`
+| RedHatDisplay | 36px | 300 | 43.2 | `.pf-c-title .pf-m-4xl` | `991px to 480px`
+| RedHatDisplay | 32px | 300 | 38.4 | `.pf-c-title .pf-m-4xl` | `479px & below`
 
 {{< code >}}
 <h1 class="pf-c-title pf-m-4xl pf-m-dark">"Design is where science and art break even."</h1>
-<section class="pf-c-page__main-section pf-m-dark-100"><h1 class="pf-c-title pf-m-4xl">"Design is where science and art break even."</h1></section>
+<section class="pf-c-page__main-section pf-m-dark-100">
+  <h1 class="pf-c-title pf-m-4xl">"Design is where science and art break even."</h1>
+</section>
 {{< /code >}}
+<h1 style="font-size: 36px; font-weight: 300; line-height: 43.2px;">"Design is where science and art break even."</h1>
+<h1 style="font-size: 32px; font-weight: 300; line-height: 38.4px;">"Design is where science and art break even."</h1>
 
 <hr class="rhd-c-divider">
 
@@ -147,11 +162,13 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 | Font family | Font size | Font weight | Line height | Class + Modifier or Element |
 | --- | --- | --- | --- | --- |
-| RedHatDisplay | 28px | 400 | 36.4 | `.pf-c-title .pf-m-3xl` |
+| RedHatDisplay | 32px | 400 | 42 | `.pf-c-title .pf-m-3xl` |
 
 {{< code >}}
 <h1 class="pf-c-title pf-m-3xl pf-m-dark">"Design is where science and art break even."</h1>
-<section class="pf-c-page__main-section pf-m-dark-100"><h1 class="pf-c-title pf-m-3xl">"Design is where science and art break even."</h1></section>
+<section class="pf-c-page__main-section pf-m-dark-100">
+  <h1 class="pf-c-title pf-m-3xl">"Design is where science and art break even."</h1>
+</section>
 {{< /code >}}
 
 <hr class="rhd-c-divider">
@@ -160,14 +177,16 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 | Font family | Font size | Font weight | Line height | Class + Modifier or Element |
 | --- | --- | --- | --- | --- |
-| RedHatDisplay | 24px | 400 | 31.2 | `.pf-c-title .pf-m-2xl` or `<h1>` |
+| RedHatDisplay | 28px | 400 | 31.2 | `.pf-c-title .pf-m-2xl` or `<h2>` |
 
 {{< code >}}
 <h1 class="pf-c-title pf-m-2xl pf-m-dark">"Design is where science and art break even."</h1>
 <div class="pf-c-content pf-m-dark">
-  <h1>"Design is where science and art break even."</h1>
+  <h2>"Design is where science and art break even."</h2>
 </div>
-<section class="pf-c-page__main-section pf-m-dark-100"><h1 class="pf-c-title pf-m-2xl">"Design is where science and art break even."</h1></section>
+<section class="pf-c-page__main-section pf-m-dark-100">
+  <h2 class="pf-c-title pf-m-2xl">"Design is where science and art break even."</h2>
+</section>
 {{< /code >}}
 
 <hr class="rhd-c-divider">
@@ -176,14 +195,16 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 | Font family | Font size | Font weight | Line height | Class + Modifier or Element |
 | --- | --- | --- | --- | --- |
-| RedHatDisplay | 20px | 400 | 30 | `.pf-c-title .pf-m-xl` or `<h2>` |
+| RedHatDisplay | 20px | 400 | 30 | `.pf-c-title .pf-m-xl` or `<h3>` |
 
 {{< code >}}
 <h1 class="pf-c-title pf-m-xl pf-m-dark">"Design is where science and art break even."</h1>
 <div class="pf-c-content pf-m-dark">
-  <h2>"Design is where science and art break even."</h2>
+  <h3>"Design is where science and art break even."</h3>
 </div>
-<section class="pf-c-page__main-section pf-m-dark-100"><h1 class="pf-c-title pf-m-xl">"Design is where science and art break even."</h1></section>
+<section class="pf-c-page__main-section pf-m-dark-100">
+  <h3 class="pf-c-title pf-m-xl">"Design is where science and art break even."</h3>
+</section>
 {{< /code >}}
 
 <hr class="rhd-c-divider">
@@ -192,14 +213,16 @@ We use the open source Red Hat Text and Red Hat Display fonts.
 
 | Font family | Font size | Font weight | Line height | Class + Modifier or Element |
 | --- | --- | --- | --- | --- |
-| RedHatDisplay | 18px | 400 | 27 | `.pf-c-title .pf-m-lg` or `<h3>` |
+| RedHatDisplay | 18px | 400 | 27 | `.pf-c-title .pf-m-lg` or `<h4>` |
 
 {{< code >}}
-<h1 class="pf-c-title pf-m-lg pf-m-dark">"Design is where science and art break even."</h1>
+<h4 class="pf-c-title pf-m-lg pf-m-dark">"Design is where science and art break even."</h4>
 <div class="pf-c-content pf-m-dark">
-  <h3>"Design is where science and art break even."</h3>
+  <h4>"Design is where science and art break even."</h4>
 </div>
-<section class="pf-c-page__main-section pf-m-dark-100"><h1 class="pf-c-title pf-m-lg">"Design is where science and art break even."</h1></section>
+<section class="pf-c-page__main-section pf-m-dark-100">
+  <h4 class="pf-c-title pf-m-lg">"Design is where science and art break even."</h4>
+</section>
 {{< /code >}}
 
 <hr class="rhd-c-divider">
@@ -221,7 +244,9 @@ We use the open source Red Hat Text and Red Hat Display fonts.
   <p><a href="#" class="pf-m-link--secondary-on-dark">Secondary link on dark</a></p>
 </div>
 <a href="#" class="pf-m-link pf-m-dark">Link on dark background without wrapper</a>
-<section class="pf-c-page__main-section pf-m-dark-100"><a href="#" class="pf-m-link pf-m-dark">"Design is where science and art break even."</a></section>
+<section class="pf-c-page__main-section pf-m-dark-100">
+  <a href="#" class="pf-m-link pf-m-dark">"Design is where science and art break even."</a>
+</section>
 {{< /code >}}
 
 <blockquote>

--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -2,6 +2,8 @@
 @import "layout/breakpoints";
 @import "typography/fonts";
 @import "typography/sizes";
+@import "typography/weights";
+@import "typography/typography";
 @import "typography/dark";
 @import "layout/spacing";
 

--- a/src/styles/rhd-theme/components/_author-tile.scss
+++ b/src/styles/rhd-theme/components/_author-tile.scss
@@ -16,18 +16,19 @@
     margin-left: var(--pf-global--spacer--sm); // 8px
     .rhd-c-video--author-name,
     .rhd-c-author--tile-name {
-      display: inline-block;  
+      display: inline-block;
     }
   }
   &-name {
     @extend .rhd-c-card__footer--author;
     a {
+      font-weight: var(--rhd-global--FontWeight-Text--medium);
       text-decoration: none;
     }
   }
   &-title {
-    font-family: "RedHatText", "Overpass", Overpass, Helvetica, Arial, sans-serif;
-    margin-top: var(--pf-global--spacer--sm);
+    font-family: $rhd-font-stack-text;
     font-size: var(--pf-global--FontSize--xs) !important; // 12px
+    margin-top: var(--pf-global--spacer--sm);
   }
 }

--- a/src/styles/rhd-theme/components/_cards.scss
+++ b/src/styles/rhd-theme/components/_cards.scss
@@ -202,9 +202,9 @@
 }
 
 .rhd-c-card__title {
-  font-family: "RedHatDisplay", "Overpass", Overpass, Helvetica, Arial, sans-serif;
+  font-family: $rhd-font-stack-display;
   font-size: var(--pf-global--FontSize--lg) !important;
-  font-weight: 400;
+  font-weight: var(--rhd-global--FontWeight-Display--medium);
   padding-bottom: 0 !important;
   margin-top: 0;
   margin-bottom: var(--pf-global--spacer--sm); // 8px;
@@ -218,20 +218,20 @@
 }
 
 .rhd-c-card__subtitle {
-  font-family: "RedHatText", "Overpass", Overpass, Helvetica, Arial, sans-serif;
+  font-family: $rhd-font-stack-text;
   margin-bottom: 0;
   font-size: var(--pf-global--FontSize--sm) !important;
   color: var(--pf-global--Color--200); // #72767b
 }
 
 .rhd-c-card__body {
-  font-family: "RedHatText", "Overpass", Overpass, Helvetica, Arial, sans-serif;
+  font-family: $rhd-font-stack-text;
   font-size: var(--pf-global--FontSize--md) !important;
   flex: 1 1 auto;
 }
 
 .rhd-c-card__footer {
-  font-family: "RedHatText", "Overpass", Overpass, Helvetica, Arial, sans-serif;
+  font-family: $rhd-font-stack-text;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -241,7 +241,7 @@
     font-size: var(--pf-global--FontSize--xs) !important;
   }
   &--author {
-    font-family: "RedHatText", "Overpass", Overpass, Helvetica, Arial, sans-serif;
+    font-family: $rhd-font-stack-text;
     background-color: #f9f9f9;
     padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm); // 4px 8px
     margin-bottom: 0;
@@ -261,8 +261,8 @@
 }
 
 .rhd-c-card__footer--cta {
-  font-family: "RedHatText", "Overpass", Overpass, Helvetica, Arial, sans-serif;
-  font-weight: 700;
+  font-family: $rhd-font-stack-text;
+  font-weight: var(--rhd-global--FontWeight-Text--medium);
   padding: 0;
   margin-top: var(--pf-global--spacer--sm); // 8px
   margin-bottom: 0;

--- a/src/styles/rhd-theme/components/_footer.scss
+++ b/src/styles/rhd-theme/components/_footer.scss
@@ -60,7 +60,7 @@
 
   &-title {
     font-size: 16px;
-    font-weight: 600;
+    font-weight: var(--rhd-global--FontWeight-Text--regular);
     color: var(--pf-global--Color--light-100);
     margin: 0 0 .5rem 0;
   }

--- a/src/styles/rhd-theme/components/_video-hero.scss
+++ b/src/styles/rhd-theme/components/_video-hero.scss
@@ -85,7 +85,7 @@
   background-color: #00b9e4;
 }
 .rhd-c-video--video-embed {
-  iframe {    
+  iframe {
     width: 100%;
     max-height: 305px;
     height: 480px;
@@ -119,10 +119,10 @@
     padding-left: 0;
   }
   h3 {
-    font-family: "RedHatDisplay", "Overpass", "Helvetica", "Arial", sans-serif;
+    font-family: $rhd-font-stack-display;
     font-size: 24px;
     line-height: 1.3;
-    font-weight: 400;
+    font-weight: var(--rhd-global--FontWeight-Display--medium);
     margin-top: 0;
     margin-bottom: var(--pf-global--spacer--md); // 16px
   }

--- a/src/styles/rhd-theme/typography/_typography.scss
+++ b/src/styles/rhd-theme/typography/_typography.scss
@@ -1,0 +1,78 @@
+.pf-c-title.pf-m-4xl {
+  @media screen and (min-width: 992px) {
+    font-family: $rhd-font-stack-display;
+    font-size: 40px;
+    weight: var(--rhd-global--FontWeight-Display--medium);
+    line-height: 53px;
+  }
+  @media screen and (max-width: 991px) {
+    font-family: $rhd-font-stack-display;
+    font-size: 36px;
+    weight: var(--rhd-global--FontWeight-Display--medium);
+    line-height: 43.2px;
+  }
+  @media screen and (max-width: 449px) {
+    font-family: $rhd-font-stack-display;
+    font-size: 32px;
+    weight: var(--rhd-global--FontWeight-Display--medium);
+    line-height: 38.4px;
+  }
+}
+
+h1,
+.pf-c-content h1,
+.pf-c-title.pf-m-3xl {
+  font-family: $rhd-font-stack-display;
+  font-size: 32px;
+  font-weight: var(--rhd-global--FontWeight-Display--medium);
+  line-height: 42px;
+}
+
+h2,
+.pf-c-content h2,
+.pf-c-title.pf-m-2xl {
+   font-family: $rhd-font-stack-display;
+   font-weight: var(--rhd-global--FontWeight-Display--medium);
+   font-size: 28px;
+   line-height: 37px;
+}
+
+h3,
+.pf-c-content h3,
+.pf-c-title.pf-m-xl {
+   font-family: $rhd-font-stack-display;
+   font-weight: var(--rhd-global--FontWeight-Display--medium);
+   font-size: 24px;
+   line-height: 31px;
+}
+
+h4,
+.pf-c-content h4,
+.pf-c-title.pf-m-lg {
+   font-family: $rhd-font-stack-display;
+   font-weight: var(--rhd-global--FontWeight-Display--medium);
+   font-size: 20px;
+   line-height: 26px;
+}
+
+p,
+.pf-c-content p {
+  font-family: $rhd-font-stack-text;
+  font-weight: var(--rhd-global--FontWeight-Display--medium);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+}
+
+a,
+.pf-c-content a {
+  font-family: $rhd-font-stack-text;
+  font-weight: var(--rhd-global--FontWeight-Display--medium);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  &:hover{
+    text-decoration: underline;
+  }
+}
+

--- a/src/styles/rhd-theme/typography/_weights.scss
+++ b/src/styles/rhd-theme/typography/_weights.scss
@@ -1,0 +1,13 @@
+$rhd-global--FontWeight-Display--regular:   300;
+$rhd-global--FontWeight-Display--medium:    400;
+$rhd-global--FontWeight-Display--bold:      700;
+$rhd-global--FontWeight-Text--regular:      600;
+$rhd-global--FontWeight-Text--medium:       700;
+
+:root {
+  --rhd-global--FontWeight-Display--regular: 300;
+  --rhd-global--FontWeight-Display--medium: 400;
+  --rhd-global--FontWeight-Display--bold: 700;
+  --rhd-global--FontWeight-Text--regular: 600;
+  --rhd-global--FontWeight-Text--medium: 700;
+}


### PR DESCRIPTION
Update the typography references to account for h1, h2, h3, h4 outside of `pf-c-content` and all other references as needed. Updated to match the information provided by UXD, based off of redhat.com and the PatternFly Elements styles.

Existing styles were updated to utilize the updated weights - variables are now used for the `font-family` and `font-weight`.

Closes https://github.com/redhat-developer/rhd-frontend/issues/267

**Updated UXD Configuration**
<img width="560" alt="a" src="https://user-images.githubusercontent.com/4032718/65688905-e5858000-e039-11e9-8352-6da42f503385.png">

**Screenshots**
![image](https://user-images.githubusercontent.com/4032718/65688718-98a1a980-e039-11e9-8fe6-4fc98bfb0ba1.png)
![image](https://user-images.githubusercontent.com/4032718/65688959-fcc46d80-e039-11e9-945e-a1bb0030c09b.png)
![image](https://user-images.githubusercontent.com/4032718/65688972-05b53f00-e03a-11e9-8848-575eacb148b9.png)
![image](https://user-images.githubusercontent.com/4032718/65688993-0ea61080-e03a-11e9-9acc-ec789ec7b2fc.png)
![image](https://user-images.githubusercontent.com/4032718/65689009-182f7880-e03a-11e9-81dd-778724d83b7f.png)
![image](https://user-images.githubusercontent.com/4032718/65689031-1fef1d00-e03a-11e9-9026-3507e47a0ee4.png)
