### PR TITLE
[NO ISSUE] Adds proper spacing between Topic page title and summary

### DIFF
--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -44,6 +44,7 @@
 @import "components/all-products-listing";
 @import "components/collection";
 @import "components/pager";
+@import "components/topic-page";
 
 pfe-cta {
   border-radius: 3px;

--- a/src/styles/rhd-theme/components/_topic-page.scss
+++ b/src/styles/rhd-theme/components/_topic-page.scss
@@ -1,0 +1,7 @@
+.topic-page__title.component {
+  padding-bottom: 0;
+  margin-bottom: var(--rhd-theme--container-spacer-md);
+}
+.topic-page__summary.component {
+  padding-top: 0;
+}


### PR DESCRIPTION
<img width="1631" alt="Screen Shot 2019-09-26 at 11 00 54 AM" src="https://user-images.githubusercontent.com/7155034/65712960-fc819d80-e04c-11e9-9ea2-7090aa5b8830.png">

<img width="1623" alt="Screen Shot 2019-09-26 at 11 01 05 AM" src="https://user-images.githubusercontent.com/7155034/65712961-fc819d80-e04c-11e9-98c7-530ed0e58f90.png">

Relates to and blocks: https://github.com/redhat-developer/developers.redhat.com/pull/3140