### PR TITLE
[SURGE-238] Multiple CTAs in Card Grid Component

### DIFF
--- a/src/data/components/card-grid/context/base/cta.toml
+++ b/src/data/components/card-grid/context/base/cta.toml
@@ -1,0 +1,92 @@
+templates = ["""
+<div class="component rhd-c-card-grid pf-c-content">
+  <div class="pf-l-flex">
+    <h2 class="pf-c-title pf-m-lg">Title for Assembly with Card Grid</h2>
+  </div>
+  <div class="pf-l-flex rhd-c-card-grid__wrapper">
+    <!-- ======== CARD COMPONENTS START HERE ========= -->
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="fas fa-newspaper"></i>
+        Quickstart
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+        <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. Must truncate after 3 lines.</p>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">
+            <a href="#" class="rhd-m-link">Author Name</a>
+          </div>
+          <div class="rhd-c-comment">
+            <i class="fas fa-comment"></i> 2
+          </div>
+        </div>
+      </div>
+    </div>
+<div class="pf-c-card rhd-c-card">
+        <img src="https://images.pexels.com/photos/417173/pexels-photo-417173.jpeg?cs=srgb&dl=altitude-clouds-cold-417173.jpg&fm=jpg" class="rhd-c-card__image"/>
+        <div class="rhd-c-card__tag">
+          <i class="fas fa-newspaper"></i>
+          Opinion
+        </div>
+        <div class="rhd-c-card-content">
+          <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Title of the article that can go to two lines only and then must truncate after it passes two lines.</a></h3>
+          <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. Must truncate after 3 lines.</p>
+          <div class="rhd-c-card__footer">
+            <div class="rhd-c-card__footer--author">
+              <a href="#" class="rhd-m-link">Author Name</a>
+            </div>
+            <div class="rhd-c-comment">
+              <i class="fas fa-comment"></i> 2
+            </div>
+          </div>
+        </div>
+      </div>
+<div class="pf-c-card rhd-c-card">
+        <img src="https://images.pexels.com/photos/462149/pexels-photo-462149.jpeg?cs=srgb&amp;dl=alpine-clouds-daylight-462149.jpg&amp;fm=jpg" class="rhd-c-card__image"/>
+        <div class="rhd-c-card__tag">
+          <i class="fas fa-newspaper"></i>
+          Quickstart
+        </div>
+        <div class="rhd-c-card-content">
+          <h3 class="rhd-c-card__title rhd-m-card-title"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+          <p class="rhd-c-card__body ">This is a short article description.</p>
+          <div class="rhd-c-card__footer">
+            <div class="rhd-c-card__footer--author">
+              <a href="#" class="rhd-m-link">Author Name</a>
+            </div>
+            <div class="rhd-c-comment">
+              <i class="fas fa-comment"></i> 2
+            </div>
+          </div>
+        </div>
+      </div>
+<div class="pf-c-card rhd-c-card">
+        <div class="rhd-c-card__tag">
+          <i class="far fa-file-code"></i>
+          Cheat sheet
+        </div>
+        <div class="rhd-c-card-content">
+          <h3 class="rhd-c-card__title rhd-m-card-title__no-image">
+            Cheat sheet title that can go to two lines only and then must truncate after it passes two lines.
+          </h3>
+          <div class="rhd-c-card__footer">
+            <div class="rhd-c-card__footer--author">
+              Author Name & Author Name
+            </div>
+          </div>
+          <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/kubernetes-cheat-sheet-cover.png?itok=io1KFs4d" class="rhd-c-card__image-body"/>
+          <div class="rhd-c-card__footer">
+            <div class="rhd-c-card__footer--cta">
+              <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    <!-- ======== END OF CARD COMPONENTS ========= -->
+  </div>
+  <div class="pf-l-flex rhd-c-card-grid__cta">
+    <a class="pf-c-button pf-m-secondary" href="https://developers.redhat.com/">Get started</a>
+  </div>
+</div>
+"""]

--- a/src/data/components/card-grid/context/base/ctas.toml
+++ b/src/data/components/card-grid/context/base/ctas.toml
@@ -1,0 +1,94 @@
+templates = ["""
+<div class="component rhd-c-card-grid pf-c-content">
+  <div class="pf-l-flex">
+    <h2 class="pf-c-title pf-m-lg">Title for Assembly with Card Grid</h2>
+  </div>
+  <div class="pf-l-flex rhd-c-card-grid__wrapper">
+    <!-- ======== CARD COMPONENTS START HERE ========= -->
+    <div class="pf-c-card rhd-c-card">
+      <div class="rhd-c-card__tag">
+        <i class="fas fa-newspaper"></i>
+        Quickstart
+      </div>
+      <div class="rhd-c-card-content">
+        <h3 class="rhd-c-card__title rhd-m-card-title__no-image"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+        <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. Must truncate after 3 lines.</p>
+        <div class="rhd-c-card__footer">
+          <div class="rhd-c-card__footer--author">
+            <a href="#" class="rhd-m-link">Author Name</a>
+          </div>
+          <div class="rhd-c-comment">
+            <i class="fas fa-comment"></i> 2
+          </div>
+        </div>
+      </div>
+    </div>
+<div class="pf-c-card rhd-c-card">
+        <img src="https://images.pexels.com/photos/417173/pexels-photo-417173.jpeg?cs=srgb&dl=altitude-clouds-cold-417173.jpg&fm=jpg" class="rhd-c-card__image"/>
+        <div class="rhd-c-card__tag">
+          <i class="fas fa-newspaper"></i>
+          Opinion
+        </div>
+        <div class="rhd-c-card-content">
+          <h3 class="rhd-c-card__title"><a href="#" class="rhd-m-link">Title of the article that can go to two lines only and then must truncate after it passes two lines.</a></h3>
+          <p class="rhd-c-card__body ">This is the article description that can go to three lines and will be followed by a footer. Must truncate after 3 lines.</p>
+          <div class="rhd-c-card__footer">
+            <div class="rhd-c-card__footer--author">
+              <a href="#" class="rhd-m-link">Author Name</a>
+            </div>
+            <div class="rhd-c-comment">
+              <i class="fas fa-comment"></i> 2
+            </div>
+          </div>
+        </div>
+      </div>
+<div class="pf-c-card rhd-c-card">
+        <img src="https://images.pexels.com/photos/462149/pexels-photo-462149.jpeg?cs=srgb&amp;dl=alpine-clouds-daylight-462149.jpg&amp;fm=jpg" class="rhd-c-card__image"/>
+        <div class="rhd-c-card__tag">
+          <i class="fas fa-newspaper"></i>
+          Quickstart
+        </div>
+        <div class="rhd-c-card-content">
+          <h3 class="rhd-c-card__title rhd-m-card-title"><a href="#" class="rhd-m-link">Title of the article</a></h3>
+          <p class="rhd-c-card__body ">This is a short article description.</p>
+          <div class="rhd-c-card__footer">
+            <div class="rhd-c-card__footer--author">
+              <a href="#" class="rhd-m-link">Author Name</a>
+            </div>
+            <div class="rhd-c-comment">
+              <i class="fas fa-comment"></i> 2
+            </div>
+          </div>
+        </div>
+      </div>
+<div class="pf-c-card rhd-c-card">
+        <div class="rhd-c-card__tag">
+          <i class="far fa-file-code"></i>
+          Cheat sheet
+        </div>
+        <div class="rhd-c-card-content">
+          <h3 class="rhd-c-card__title rhd-m-card-title__no-image">
+            Cheat sheet title that can go to two lines only and then must truncate after it passes two lines.
+          </h3>
+          <div class="rhd-c-card__footer">
+            <div class="rhd-c-card__footer--author">
+              Author Name & Author Name
+            </div>
+          </div>
+          <img src="https://developers.redhat.com/sites/default/files/styles/card_small/public/kubernetes-cheat-sheet-cover.png?itok=io1KFs4d" class="rhd-c-card__image-body"/>
+          <div class="rhd-c-card__footer">
+            <div class="rhd-c-card__footer--cta">
+              <a href="#" class="rhd-m-link">Download <i class="fas fa-arrow-right"></i></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    <!-- ======== END OF CARD COMPONENTS ========= -->
+  </div>
+  <div class="pf-l-flex rhd-c-card-grid__cta">
+    <a class="pf-c-button pf-m-secondary" href="https://developers.redhat.com/">Get started</a>
+    <a class="pf-c-button pf-m-secondary" href="https://developers.redhat.com/">Download</a>
+    <a class="pf-c-button pf-m-secondary" href="https://developers.redhat.com/">More Resources</a>
+  </div>
+</div>
+"""]

--- a/src/data/components/card-grid/variants.toml
+++ b/src/data/components/card-grid/variants.toml
@@ -32,3 +32,13 @@ order = 6
 id = "center-aligned-logos"
 name = "Center Aligned with logos"
 order = 7
+
+[[variant]]
+id = "cta"
+name = "With CTA"
+order = 8
+
+[[variant]]
+id = "ctas"
+name = "With multiple CTAs"
+order = 9

--- a/src/styles/rhd-theme/components/_card-grid.scss
+++ b/src/styles/rhd-theme/components/_card-grid.scss
@@ -29,6 +29,14 @@
             --pf-l-flex--spacer: var(--pf-l-flex--spacer--lg);
         }
     }
+
+    .rhd-c-card-grid__wrapper {
+        margin-bottom: 8px;
+    }
+
+    .rhd-c-card-grid__cta .pf-c-button:not(:last-of-type) {
+        margin-right: 24px;
+    }
 }
 
 // OTHER VISUAL STYLES


### PR DESCRIPTION
This adds 2 more variants to the Card Grid component: a Card Grid with 1
CTA and another with multiple CTAs. The spacing between the cards and
the CTA(s) (below) is 32px, per SJ's comment in Github, and the spacing
between CTAs in a row is 24px.

### With CTA

<img width="1415" alt="Screen Shot 2019-09-27 at 7 45 51 AM" src="https://user-images.githubusercontent.com/7155034/65778520-ec27fc00-e0fa-11e9-94c0-3e4cd9b23d1c.png">


### With multiple CTAs

<img width="1421" alt="Screen Shot 2019-09-27 at 7 45 56 AM" src="https://user-images.githubusercontent.com/7155034/65778531-f1854680-e0fa-11e9-81d6-cb54f077c110.png">
