### PR TITLE
[SURGE-245] Add Code Snippet visual styles

### DIFF
--- a/src/data/components/code-snippet/context/base/no_padding_bottom.toml
+++ b/src/data/components/code-snippet/context/base/no_padding_bottom.toml
@@ -1,5 +1,5 @@
 templates = ["""
-  <pre class="assembly assembly-type-code_snippet"><code>oc new-project knativetutorial
+  <pre class="assembly assembly-type-code_snippet no-padding-bottom"><code>oc new-project knativetutorial
 oc adm policy add-scc-to-user privileged -z default
 oc adm policy add-scc-to-user anyuid -z default</code></pre>
 """]

--- a/src/data/components/code-snippet/context/base/no_padding_top.toml
+++ b/src/data/components/code-snippet/context/base/no_padding_top.toml
@@ -1,5 +1,5 @@
 templates = ["""
-  <pre class="assembly assembly-type-code_snippet"><code>oc new-project knativetutorial
+  <pre class="assembly assembly-type-code_snippet no-padding-top"><code>oc new-project knativetutorial
 oc adm policy add-scc-to-user privileged -z default
 oc adm policy add-scc-to-user anyuid -z default</code></pre>
 """]

--- a/src/data/components/code-snippet/variants.toml
+++ b/src/data/components/code-snippet/variants.toml
@@ -2,3 +2,13 @@
 id = "default"
 name = "Code snippet"
 order = 1
+
+[[variant]]
+id = "no_padding_bottom"
+name = "No padding bottom"
+order = 2
+
+[[variant]]
+id = "no_padding_top"
+name = "No padding top"
+order = 3

--- a/src/styles/rhd-theme/components/_code-snippet.scss
+++ b/src/styles/rhd-theme/components/_code-snippet.scss
@@ -1,5 +1,15 @@
-.assembly-type-code_snippet .hljs {
-  padding: 0;
-  background-color: #f9f9f9;
-  color: #0a0a0a;
+.assembly-type-code_snippet {
+  & .hljs {
+    padding: 0;
+    background-color: #f9f9f9;
+    color: #0a0a0a;
+  }
+
+  /** Visual styles **/
+  &.no-padding-bottom {
+    margin-bottom: 0;
+  }
+  &.no-padding-top {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
This adds the 2 visual styles for the Code Snippet assembly type: No
padding bottom and No padding top.

### Screenshots

#### Default
<img width="831" alt="Screen Shot 2019-09-27 at 1 16 24 PM" src="https://user-images.githubusercontent.com/7155034/65799555-4049d500-e129-11e9-8230-8b585a6b166f.png">

#### No padding bottom
<img width="672" alt="Screen Shot 2019-09-27 at 1 16 32 PM" src="https://user-images.githubusercontent.com/7155034/65799556-4049d500-e129-11e9-86f0-4d5453148d3d.png">

#### No padding top
<img width="694" alt="Screen Shot 2019-09-27 at 1 16 37 PM" src="https://user-images.githubusercontent.com/7155034/65799558-4049d500-e129-11e9-8ed4-0c3d445da025.png">