### PR TITLE
[SURGE-291] Update Rich Text Columns assembly type visual styles

### DIFF
--- a/src/data/components/rich_text_columns/context/base/rich_text_columns.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns.toml
@@ -1,5 +1,5 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns pf-c-content pf-c-page__main-section">
   <h1 class="pf-u-mb-lg">Value of Red Hat Fuse</h1>
   <div class="pf-l-grid pf-m-gutter rich-text__content">
     <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md pf-m-3-col-on-lg">

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_dark.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_dark.toml
@@ -1,7 +1,7 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns dark pf-c-content component">
   <h1 class="pf-u-mb-lg">Value of Red Hat Fuse</h1>
-  <div class="pf-l-grid pf-m-gutter rich-text__content">
+  <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md pf-m-3-col-on-lg">
       <h3>Fuse is enterprise-ready.</h3>
       <p>It starts with the integration framework Camel and then adds a variety of extensions that enterprise developers can use to build in routes and connect JavaEE components. It can use code written in the Red Hat JBoss Enterprise Application Platform and Red Hat Container Development Kit. Fuse can easily provision scalable applications for the largest deployments too.</p>

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_dark.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_dark.toml
@@ -1,5 +1,5 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns dark pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns dark pf-c-content pf-c-page__main-section">
   <h1 class="pf-u-mb-lg">Value of Red Hat Fuse</h1>
   <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md pf-m-3-col-on-lg">

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_featured.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_featured.toml
@@ -1,7 +1,7 @@
 templates = ["""
-<section class="pf-c-content">
+<section class="assembly assembly-type-rich_text_columns pf-c-content component">
   <h1 class="pf-u-mb-lg">Featured Topics</h1>
-  <div class="pf-l-grid pf-m-gutter">
+  <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-3-col-on-md">
       <div class="pf-c-card rhd-c-card">
         <img src="https://developers.redhat.com/sites/default/files/inline-images/kubernetes.png" class="rhd-c-card__image">

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_featured.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_featured.toml
@@ -1,5 +1,5 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns pf-c-content pf-c-page__main-section">
   <h1 class="pf-u-mb-lg">Featured Topics</h1>
   <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-3-col-on-md">

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_no_padding_bottom.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_no_padding_bottom.toml
@@ -1,5 +1,5 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns no-padding-bottom pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns no-padding-bottom pf-c-content pf-c-page__main-section">
   <h1 class="pf-u-mb-lg">Value of Red Hat Fuse</h1>
   <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md pf-m-3-col-on-lg">

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_no_padding_bottom.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_no_padding_bottom.toml
@@ -1,7 +1,7 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns no-padding-bottom pf-c-content component">
   <h1 class="pf-u-mb-lg">Value of Red Hat Fuse</h1>
-  <div class="pf-l-grid pf-m-gutter rich-text__content">
+  <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md pf-m-3-col-on-lg">
       <h3>Fuse is enterprise-ready.</h3>
       <p>It starts with the integration framework Camel and then adds a variety of extensions that enterprise developers can use to build in routes and connect JavaEE components. It can use code written in the Red Hat JBoss Enterprise Application Platform and Red Hat Container Development Kit. Fuse can easily provision scalable applications for the largest deployments too.</p>

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_no_padding_top.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_no_padding_top.toml
@@ -1,7 +1,7 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns no-padding-top pf-c-content component">
   <h1 class="pf-u-mb-lg">Value of Red Hat Fuse</h1>
-  <div class="pf-l-grid pf-m-gutter rich-text__content">
+  <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md pf-m-3-col-on-lg">
       <h3>Fuse is enterprise-ready.</h3>
       <p>It starts with the integration framework Camel and then adds a variety of extensions that enterprise developers can use to build in routes and connect JavaEE components. It can use code written in the Red Hat JBoss Enterprise Application Platform and Red Hat Container Development Kit. Fuse can easily provision scalable applications for the largest deployments too.</p>

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_no_padding_top.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_no_padding_top.toml
@@ -1,5 +1,5 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns no-padding-top pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns no-padding-top pf-c-content pf-c-page__main-section">
   <h1 class="pf-u-mb-lg">Value of Red Hat Fuse</h1>
   <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md pf-m-3-col-on-lg">

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_three.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_three.toml
@@ -1,9 +1,9 @@
 templates = ["""
-<section class="pf-c-content">
+<section class="assembly assembly-type-rich_text_columns three-up pf-c-content component">
   <h1>EAP integration and open source projects</h1>
   <p><b>EAP comes in two versions—one standalone, and one that runs in a variety of OpenShift implementations. This <a href="#">page shows the differences between the two versions.</a></b></p>
   <p>EAP also integrates code from the following open source projects:</p>
-  <div class="pf-l-grid pf-m-gutter">
+  <div class="rich-text__content pf-l-grid pf-m-gutter">
     <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
       <ul>
         <li>Hibernate ORM (<a href="#">RH docs</a> / <a href="#">OS project</a>) a relational database persistence project</li>

--- a/src/data/components/rich_text_columns/context/base/rich_text_columns_three.toml
+++ b/src/data/components/rich_text_columns/context/base/rich_text_columns_three.toml
@@ -1,5 +1,5 @@
 templates = ["""
-<section class="assembly assembly-type-rich_text_columns three-up pf-c-content component">
+<section class="assembly assembly-type-rich_text_columns three-up pf-c-content pf-c-page__main-section">
   <h1>EAP integration and open source projects</h1>
   <p><b>EAP comes in two versions—one standalone, and one that runs in a variety of OpenShift implementations. This <a href="#">page shows the differences between the two versions.</a></b></p>
   <p>EAP also integrates code from the following open source projects:</p>

--- a/src/data/components/rich_text_columns/variants.toml
+++ b/src/data/components/rich_text_columns/variants.toml
@@ -1,14 +1,29 @@
 [[variant]]
 id = "rich_text_columns"
-name = "Four Across - Dark"
+name = "Light (default/no visual style)"
 order = 1
+
+[[variant]]
+id = "rich_text_columns_dark"
+name = "Dark"
+order = 2
 
 [[variant]]
 id = "rich_text_columns_three"
 name = "Three Across - Light"
-order = 2
+order = 3
 
 [[variant]]
 id = "rich_text_columns_featured"
 name = "Featured Topics - Cards"
-order = 3
+order = 4
+
+[[variant]]
+id = "rich_text_columns_no_padding_bottom"
+name = "No Padding Bottom"
+order = 5
+
+[[variant]]
+id = "rich_text_columns_no_padding_top"
+name = "No Padding Top"
+order = 6

--- a/src/styles/rhd-theme/_rhd-theme.scss
+++ b/src/styles/rhd-theme/_rhd-theme.scss
@@ -45,6 +45,7 @@
 @import "components/collection";
 @import "components/pager";
 @import "components/topic-page";
+@import "components/rich-text-columns";
 
 pfe-cta {
   border-radius: 3px;

--- a/src/styles/rhd-theme/components/_rich-text-columns.scss
+++ b/src/styles/rhd-theme/components/_rich-text-columns.scss
@@ -1,0 +1,17 @@
+.assembly-type-rich_text_columns {
+  
+  /** Visual styles **/
+  &.dark {
+    .rich-text__content {
+      color: var(--rhd-theme--component-font--color-light);
+    }
+  }
+
+  &.no-padding-bottom {
+    padding-bottom: 0;
+  }
+
+  &.no-padding-top {
+    padding-top: 0;
+  }
+}

--- a/src/styles/rhd-theme/components/_rich-text-columns.scss
+++ b/src/styles/rhd-theme/components/_rich-text-columns.scss
@@ -1,8 +1,13 @@
-.assembly-type-rich_text_columns {
+.assembly.assembly-type-rich_text_columns {
   
   /** Visual styles **/
   &.dark {
-    .rich-text__content {
+    background: var(--rhd-theme--component-background--color-dark);
+    color: var(--rhd-theme--component-font--color-light);
+
+    .rich-text__content,
+    h1, h2, h3, h4, h5, h6,
+    p {
       color: var(--rhd-theme--component-font--color-light);
     }
   }


### PR DESCRIPTION
This updates the visual styles of the Rich Text Columns assembly type.

Closes #291 
Unblocks https://github.com/redhat-developer/developers.redhat.com/pull/3147

### Remaining work (hopefully does not need to be addressed now)

Eventually, we should make the three-up visual style work as a style on the .assembly -level container element, but I do not think that is a priority right now.

### Screenshots

<img width="650" alt="Screen Shot 2019-10-01 at 10 33 24 AM" src="https://user-images.githubusercontent.com/7155034/65985636-0cc3bf00-e437-11e9-8c7b-007efb617431.png">

<img width="656" alt="Screen Shot 2019-10-01 at 10 33 32 AM" src="https://user-images.githubusercontent.com/7155034/65985637-0cc3bf00-e437-11e9-827f-7399aa922c24.png">

<img width="657" alt="Screen Shot 2019-10-01 at 10 33 40 AM" src="https://user-images.githubusercontent.com/7155034/65985639-0cc3bf00-e437-11e9-843d-a44850b8e1e0.png">

<img width="659" alt="Screen Shot 2019-10-01 at 10 33 49 AM" src="https://user-images.githubusercontent.com/7155034/65985640-0cc3bf00-e437-11e9-8dc3-9a1f1b835654.png">

<img width="639" alt="Screen Shot 2019-10-01 at 10 33 55 AM" src="https://user-images.githubusercontent.com/7155034/65985641-0cc3bf00-e437-11e9-8068-7ff7550df711.png">
