### PR TITLE
Update _curated-events.scss

### DIFF
--- a/src/styles/rhd-theme/components/_curated-events.scss
+++ b/src/styles/rhd-theme/components/_curated-events.scss
@@ -4,8 +4,11 @@
 
   &__item {
     @extend .pf-u-pt-lg;
-    @extend .pf-u-pb-lg;
     border-top: 2px dotted #D2D3D4;
+
+    p {
+      margin-bottom: var(--pf-c-content--MarginBottom);
+    }
   }
   
   &__item-title {


### PR DESCRIPTION
Closes #325 

Removes bottom padding from event list items. I also had to set the bottom margin of the event description so that it cover the case of an event item with no speakers.

![image](https://user-images.githubusercontent.com/8727648/66536408-135ad200-eada-11e9-97bf-1e2373b25d98.png)
