### PR TITLE
Fixes Author Tile width

### DIFF
--- a/src/styles/rhd-theme/components/_author-tile.scss
+++ b/src/styles/rhd-theme/components/_author-tile.scss
@@ -4,8 +4,9 @@
   padding: var(--pf-global--spacer--xs);
   &-hero {
     img {
-      width: 45px;
-      height: 45px;
+      min-width: 50px;
+      max-width: 50px;
+      height: 50px;
       border-radius: 50%;
     }
   }


### PR DESCRIPTION
Fixes the Author tile image distorting with multi-line position field.

Closes #311 

![image](https://user-images.githubusercontent.com/8727648/66538022-ea3d4000-eadf-11e9-92ed-c383f83f8df0.png)
