### PR TITLE
Remove bottom margin from topics nav

### DIFF
--- a/src/styles/rhd-theme/components/_navigation.scss
+++ b/src/styles/rhd-theme/components/_navigation.scss
@@ -188,7 +188,6 @@ $custom-nav-breakpoint: 1150px;
   max-width: 100%;
   margin: 0 auto;
   justify-self: center;
-  margin-bottom: var(--pf-global--spacer--md);
   padding: 0 var(--rhd-theme--container-spacer-3xl);
 
   @media screen and (min-width: $pf-global--breakpoint--xl) {


### PR DESCRIPTION
Remove the bottom margin from the Topics navbar. This will now rely on the assembly's top margin/padding to render proper spacing.

Fixes https://github.com/redhat-developer/rhd-frontend/issues/382

Examples w/bottom margin removed.
![image](https://user-images.githubusercontent.com/4032718/67224778-f7233300-f3ff-11e9-877e-97f336810925.png)


![image](https://user-images.githubusercontent.com/4032718/67224705-d064fc80-f3ff-11e9-8420-6f4bd488ab90.png)
