### PR TITLE
Fix mobile layouts for jump nav

### DIFF
--- a/src/data/components/jump-to-nav/context/base/default.toml
+++ b/src/data/components/jump-to-nav/context/base/default.toml
@@ -1,10 +1,22 @@
 templates = ["""
 <div class="rhd-jump-to-nav">
-    <a href='#'>Item2</a>
-    <a href='#'>Item3</a>
-    <a href='#'>Item4</a>
-    <a href='#'>Item5</a>
-    <a href='#'>Item6</a>
+    <a href='#'>Oracle JDK Alternative</a>
+    <a href='#'>Post &amp; Guides</a>
+    <a href='#'>Docs</a>
+    <a href='#'>Support</a>
+    <a href='#'>Contact</a>
+</div>
+<div class="rhd-jump-to-nav">
+    <a href='#'>Oracle JDK Alternative</a>
+    <a href='#'>Post &amp; Guides</a>
+    <a href='#'>Docs</a>
+    <a href='#'>Support</a>
+    <a href='#'>Contact</a>
+    <a href='#'>Docs</a>
+    <a href='#'>Support</a>
+    <a href='#'>Contact</a>
+    <a href='#'>Post &amp; Guides</a>
+    <a href='#'>Oracle JDK Alternative</a>
 </div>
 """]
 

--- a/src/styles/rhd-theme/components/_jump-to-nav.scss
+++ b/src/styles/rhd-theme/components/_jump-to-nav.scss
@@ -3,18 +3,25 @@
 .rhd-jump-to-nav {
   background-color: var(--pf-global--primary-color--100);
   @include with-background-padding;
+  padding-right: var(--rhd-theme--container-spacer-lg);
+  padding-left: var(--rhd-theme--container-spacer-lg);
   @media screen and (max-width: $pf-global--breakpoint--lg) {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: repeat(4, auto);
     grid-column-gap: var(--pf-global--spacer--lg);
     grid-row-gap: var(--pf-global--spacer--lg);
     text-align: center;
   }
   @media screen and (max-width: $pf-global--breakpoint--md) {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(3, auto);
   }
   @media screen and (max-width: $pf-global--breakpoint--sm) {
-    display: none;
+    // display: none;
+    grid-template-columns: repeat(2, auto);
+  }
+  @media screen and (max-width: $pf-global--breakpoint--xs) {
+    // display: none;
+    grid-template-columns: repeat(1, auto);
   }
 }
 
@@ -32,9 +39,9 @@
   }
 
   @media screen and (max-width: $pf-global--breakpoint--lg) {
-    border: 1px solid var(--pf-global--active-color--300);
+    border: 1px solid var(--pf-global--Color--light-100);
     font-size: var(--pf-global--FontSize--md);
-    padding: .35em .7em;
+    padding: 6px 8px;
     margin: 0;
     &:hover,
     &:focus,


### PR DESCRIPTION
Updates the layouts for the jump-to-nav for the various mobile viewports. Change active border to white, per UX specs. Updates spacers to match UX specs.

Fixes https://github.com/redhat-developer/rhd-frontend/issues/375

### max-width: 320px
![image](https://user-images.githubusercontent.com/4032718/67413202-b574c280-f58e-11e9-8aa1-0d784096cb28.png)
### max-width: 480px
![image](https://user-images.githubusercontent.com/4032718/67413237-c9202900-f58e-11e9-8e3b-d09fc8acb457.png)
### max-width: 768px
![image](https://user-images.githubusercontent.com/4032718/67413294-df2de980-f58e-11e9-814f-b7bcd1b38704.png)
### max-width: 1024px
![image](https://user-images.githubusercontent.com/4032718/67413329-ee149c00-f58e-11e9-8805-f821d26db7e5.png)
### default
![image](https://user-images.githubusercontent.com/4032718/67413360-fec51200-f58e-11e9-8b40-e4209f5d9f4e.png)
