### PR TITLE
Set author name size to 12px

### DIFF
--- a/src/styles/rhd-theme/components/_author-tile.scss
+++ b/src/styles/rhd-theme/components/_author-tile.scss
@@ -20,6 +20,7 @@
   &-name {
     @extend .rhd-c-card__footer--author;
     a {
+      font-size: var(--pf-global--FontSize--xs); // 12px
       font-weight: var(--rhd-global--FontWeight-Text--medium);
       text-decoration: none;
       .dark & {


### PR DESCRIPTION
Update the size of the Author name on the author tile to be `12px`, rather than `16px`.

Fixes https://github.com/redhat-developer/rhd-frontend/issues/342

Various demo screenshots:
![Screenshot_2019-10-23 Author Tile Component – RHD Front-end Code and Documentation](https://user-images.githubusercontent.com/4032718/67414539-4ba9e800-f591-11e9-8029-1f7cbf0f2a24.png)
![Screenshot_2019-10-23 Curated Events (Event List) – RHD Front-end Code and Documentation](https://user-images.githubusercontent.com/4032718/67414546-4d73ab80-f591-11e9-88e8-ce06451473a9.png)
![Screenshot_2019-10-23 Curated Events (Event List) – RHD Front-end Code and Documentation2](https://user-images.githubusercontent.com/4032718/67414549-4f3d6f00-f591-11e9-8a72-57266132b9c8.png)
![Screenshot_2019-10-23 Events Hero – RHD Front-end Code and Documentation](https://user-images.githubusercontent.com/4032718/67414554-51073280-f591-11e9-9c64-7f2fa7cdfbff.png)
