### PR TITLE
Update demo environment with grid examples

### DIFF
--- a/src/docs/content/patterns/layout/grid.md
+++ b/src/docs/content/patterns/layout/grid.md
@@ -6,66 +6,246 @@ tags: ["layout"]
 categories: ["layout"]
 ---
 
-{{< code >}}<section class="pf-l-grid pf-m-gutter">
-    <div class="" style="padding: 1em; background-color:orange; height: 50px;">
-        No Column Width
+<style>
+  .pf-l-grid > * {
+    border: 1px dashed #000;
+    font-weight: 700;
+    padding: 1em;
+  }
+  hr {
+    margin: 3em 0;
+  }
+</style>
+
+<nav class="pf-c-nav" aria-label="Local">
+  <ul class="pf-c-nav__tertiary-list">
+    <li class="pf-c-nav__item">
+      <a href="#base-grid" class="pf-c-nav__link">
+        Base grid
+      </a>
+    </li>
+  </ul>
+</nav>
+
+## Base grid
+{{< code >}}
+<section class="pf-l-grid">
+  <div class="pf-l-grid__item pf-m-12-col">12 col</div>
+  <div class="pf-l-grid__item pf-m-11-col">11 col</div><div class="pf-l-grid__item pf-m-1-col">1 col</div>
+  <div class="pf-l-grid__item pf-m-10-col">10 col</div><div class="pf-l-grid__item pf-m-2-col">2 col</div>
+  <div class="pf-l-grid__item pf-m-9-col">9 col</div><div class="pf-l-grid__item pf-m-3-col">3 col</div>
+  <div class="pf-l-grid__item pf-m-8-col">8 col</div><div class="pf-l-grid__item pf-m-4-col">4 col</div>
+  <div class="pf-l-grid__item pf-m-7-col">7 col</div><div class="pf-l-grid__item pf-m-5-col">5 col</div>
+  <div class="pf-l-grid__item pf-m-6-col">6 col</div><div class="pf-l-grid__item pf-m-6-col">6 col</div>
+</section>
+{{< /code >}}
+
+<hr>
+
+## Base grid with gutters
+{{< code >}}
+<section class="pf-l-grid pf-m-gutter">
+  <div class="pf-l-grid__item pf-m-12-col">12 col</div>
+  <div class="pf-l-grid__item pf-m-11-col">11 col</div><div class="pf-l-grid__item pf-m-1-col">1 col</div>
+  <div class="pf-l-grid__item pf-m-10-col">10 col</div><div class="pf-l-grid__item pf-m-2-col">2 col</div>
+  <div class="pf-l-grid__item pf-m-9-col">9 col</div><div class="pf-l-grid__item pf-m-3-col">3 col</div>
+  <div class="pf-l-grid__item pf-m-8-col">8 col</div><div class="pf-l-grid__item pf-m-4-col">4 col</div>
+  <div class="pf-l-grid__item pf-m-7-col">7 col</div><div class="pf-l-grid__item pf-m-5-col">5 col</div>
+  <div class="pf-l-grid__item pf-m-6-col">6 col</div><div class="pf-l-grid__item pf-m-6-col">6 col</div>
+</section>
+{{< /code >}}
+
+<hr>
+
+## Smart grid
+{{< code >}}
+<div class="pf-l-grid pf-m-all-6-col-on-sm pf-m-all-4-col-on-md pf-m-all-2-col-on-lg pf-m-all-1-col-on-xl">
+  <div class="pf-l-grid__item">
+    item 1
+  </div>
+  <div class="pf-l-grid__item">
+    item 2
+  </div>
+  <div class="pf-l-grid__item">
+    item 3
+  </div>
+  <div class="pf-l-grid__item">
+    item 4
+  </div>
+  <div class="pf-l-grid__item">
+    item 5
+  </div>
+  <div class="pf-l-grid__item">
+    item 6
+  </div>
+  <div class="pf-l-grid__item">
+    item 7
+  </div>
+  <div class="pf-l-grid__item">
+    item 8
+  </div>
+  <div class="pf-l-grid__item">
+    item 9
+  </div>
+  <div class="pf-l-grid__item">
+    item 10
+  </div>
+  <div class="pf-l-grid__item">
+    item 11
+  </div>
+  <div class="pf-l-grid__item">
+    item 12
+  </div>
+</div>
+{{< /code >}}
+
+<hr>
+
+## Row span
+{{< code >}}
+<div class="pf-l-grid pf-m-gutter">
+  <div class="pf-l-grid__item pf-m-8-col">
+    8 col
+  </div>
+  <div class="pf-l-grid__item pf-m-4-col pf-m-2-row">
+    4 col, 2 row
+  </div>
+  <div class="pf-l-grid__item pf-m-2-col pf-m-3-row">
+    2 col, 3 row
+  </div>
+  <div class="pf-l-grid__item pf-m-2-col">
+    2 col
+  </div>
+  <div class="pf-l-grid__item pf-m-4-col">
+    4 col
+  </div>
+  <div class="pf-l-grid__item pf-m-2-col">
+    2 col
+  </div>
+  <div class="pf-l-grid__item pf-m-2-col">
+    2 col
+  </div>
+  <div class="pf-l-grid__item pf-m-2-col">
+    2 col
+  </div>
+  <div class="pf-l-grid__item pf-m-4-col">
+    4 col
+  </div>
+  <div class="pf-l-grid__item pf-m-2-col">
+    2 col
+  </div>
+  <div class="pf-l-grid__item pf-m-4-col">
+    4 col
+  </div>
+  <div class="pf-l-grid__item pf-m-4-col">
+    4 col
+  </div>
+</div>
+{{< /code >}}
+
+<hr>
+
+## Example
+{{< code >}}
+<div class="pf-l-grid">
+  <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-md">
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item pf-m-12-col pf-u-mx-auto pf-u-my-0">
+        <img src="https://via.placeholder.com/350x200.png?text=Red+Hat" alt="Red Hat">
+      </div>
+      <div class="pf-l-grid__item pf-m-12-col pf-u-text-align-center">
+        Learn about the Developer program
+      </div>
     </div>
-</section>{{< /code >}}
-{{< code >}}<section class="pf-l-grid pf-m-gutter">
-    <div class="pf-m-6-col pf-m-offset-6-col" style="padding: 1em; background-color:orange; height: 50px;">
-        Static Column Width: 6
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-md">
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item pf-m-12-col pf-u-mx-auto pf-u-my-0">
+        <img src="https://via.placeholder.com/350x200.png?text=IBM" alt="IBM">
+      </div>
+      <div class="pf-l-grid__item pf-m-12-col pf-u-text-align-center">
+        Learn about the Red Hat and Communities
+      </div>
     </div>
-</section>{{< /code >}}
-{{< code >}}<section class="pf-l-grid pf-m-gutter">
-    <div class="pf-m-10-col-on-lg pf-m-offset-2-col-on-lg" style="padding: 1em; background-color:red; height: 50px;">
-        Dynamic Column Width: 10
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col pf-m-3-col-on-md pf-m-3-row-on-md">
+    <h2>Latest articles on topic</h2>
+    article text
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col pf-m-9-col-on-md">
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item">
+        <img src="https://via.placeholder.com/350x200?text=Hello+world" alt="Hello World">
+      </div>
+      <div class="pf-l-grid__item">
+        Body content
+      </div>
+      <div class="pf-l-grid__item">
+        Cards
+      </div>
     </div>
-</section>{{< /code >}}
-{{< code >}}<section class="pf-l-grid pf-m-gutter">
-    <div class="pf-m-8-col-on-lg pf-m-offset-4-col-on-lg" style="padding: 1em; background-color:green; height: 50px;">
-        Dynamic Column Width: 8
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col">
+    <h2>Build here, go anywhere</h2>
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-md">
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item pf-m-12-col">
+        Full width card
+      </div>
+      <div class="pf-l-grid__item pf-m-6-col">
+        Half width card
+      </div>
+      <div class="pf-l-grid__item pf-m-6-col">
+        Half width card
+      </div>
     </div>
-</section>{{< /code >}}
-{{< code >}}<section class="pf-l-grid pf-m-gutter">
-    <div class="pf-m-6-col-on-lg pf-m-offset-5-col-on-lg" style="padding: 1em; background-color:blue; height: 50px;">
-        Dynamic Column Width: 6
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-md">
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-md pf-m-2-row-on-md">
+        Card that extends over two rows on medium, 1 row on small
+      </div>
+      <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-md">
+        Single row card
+      </div>
+      <div class="pf-l-grid__item pf-m-12-col pf-m-6-col-on-md">
+        Single row card
+      </div>
     </div>
-</section>{{< /code >}}
-{{< code >}}<section class="pf-l-grid pf-m-gutter">
-    <div class="pf-l-grid pf-m-gutter pf-m-all-6-col" style="padding:var(--pf-theme--container-spacer);">
-        <div>
-            <div style="background: #EEE;">
-                <div style="padding:var(--pf-theme--container-spacer);">No Column Width</div>
-            </div>
-        </div>
-        <div>
-            <div style="background: #EEE;">
-                <div style="padding: 16px;">No Column Width</div>
-            </div>
-        </div>
-        <div>
-            <div style="background: #EEE;">
-                <div style="padding: 16px;">No Column Width</div>
-            </div>
-        </div>
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col">
+    <h2>Featured resources</h2>
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col pf-m-3-col-on-md pf-m-2-row-on-md">
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item pf-m-12-col">
+        <h3>2 min videos to get started</h3>
+      </div>
     </div>
-</section>{{< /code >}}
-{{< code >}}<section class="pf-l-grid pf-m-gutter">
-    <div class="pf-l-grid pf-m-gutter pf-m-all-4-col" style="background-color:orange;padding:var(--pf-theme--container-spacer);">
-        <div>
-            <div style="background: #EEE;">
-                <div style="padding: 16px;">No Column Width</div>
-            </div>
-        </div>
-        <div>
-            <div style="background: #EEE;">
-                <div style="padding: 16px;">No Column Width</div>
-            </div>
-        </div>
-        <div>
-            <div style="background: #EEE;">
-                <div style="padding: 16px;">No Column Width</div>
-            </div>
-        </div>
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item">
+        Vertical card list
+      </div>
     </div>
-</section>{{< /code >}}
+  </div>
+  <div class="pf-l-grid__item pf-m-12-col pf-m-9-col-on-md">
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item pf-m-12-col">
+        <h3>eBooks and cheat sheets</h3>
+      </div>
+    </div>
+    <div class="pf-l-grid">
+      <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+        Card
+      </div>
+      <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+        Card
+      </div>
+      <div class="pf-l-grid__item pf-m-12-col pf-m-4-col-on-md">
+        Vertical card list
+      </div>
+    </div>
+  </div>
+</div>
+{{< /code >}}

--- a/src/docs/content/patterns/layout/grid.md
+++ b/src/docs/content/patterns/layout/grid.md
@@ -7,6 +7,12 @@ categories: ["layout"]
 ---
 
 <style>
+  nav.pf-c-nav.jump-nav {
+    position: sticky;
+    top: 0;
+    background-color: #fff;
+    margin-bottom: 25px;
+  }
   .pf-l-grid > * {
     border: 1px dashed #000;
     font-weight: 700;
@@ -17,11 +23,31 @@ categories: ["layout"]
   }
 </style>
 
-<nav class="pf-c-nav" aria-label="Local">
+<nav class="pf-c-nav jump-nav" aria-label="Local">
   <ul class="pf-c-nav__tertiary-list">
     <li class="pf-c-nav__item">
       <a href="#base-grid" class="pf-c-nav__link">
-        Base grid
+        <i class="fad fa-circle"></i> Base grid
+      </a>
+    </li>
+    <li class="pf-c-nav__item">
+      <a href="#base-grid-with-gutters" class="pf-c-nav__link">
+        <i class="fad fa-circle"></i> Base grid with gutters
+      </a>
+    </li>
+    <li class="pf-c-nav__item">
+      <a href="#smart-grid" class="pf-c-nav__link">
+        <i class="fad fa-circle"></i> Smart grid
+      </a>
+    </li>
+    <li class="pf-c-nav__item">
+      <a href="#row-span" class="pf-c-nav__link">
+        <i class="fad fa-circle"></i> Row span
+      </a>
+    </li>
+    <li class="pf-c-nav__item">
+      <a href="#example" class="pf-c-nav__link">
+        <i class="fad fa-circle"></i> Example
       </a>
     </li>
   </ul>

--- a/src/docs/themes/rhd-docs/layouts/partials/header.html
+++ b/src/docs/themes/rhd-docs/layouts/partials/header.html
@@ -1,19 +1,44 @@
 <header role="banner" class="pf-c-page__header" style="z-index: 100;">
   <div class="pf-c-page__header-brand">
-    <a class="pf-c-page__header-brand-link">
+    <a class="pf-c-page__header-brand-link" href="/">
       <img class="pf-c-brand" src="https://developers.redhat.com/sites/default/files/styles/teaser/public/externals/e684ea8849af25532d2f2c5ad1c6dab4.png" alt="PatternFly logo">
     </a>
   </div>
   <div class="pf-c-page__header-nav">
     <nav class="pf-c-nav pf-m-end" id="page-layout-horizontal-nav-horizontal-nav" aria-label="Global">
       <ul class="pf-c-nav__horizontal-list">
-        {{ range $.Site.Taxonomies.categories.page }}
+        <!-- {{ range sort $.Site.Taxonomies.categories.page_example "Title" "ascending"}}
         <li class="pf-c-nav__item">
           <a href="{{ .Permalink }}" class="pf-c-nav__link">
             {{ .Title }}
           </a>
         </li>
-        {{ end }}
+        {{ end }} -->
+        <li class="pf-c-nav__item">
+          <a href="/categories/" class="pf-c-nav__link">
+            Categories
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="/components/" class="pf-c-nav__link">
+            Components
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="/pages/" class="pf-c-nav__link">
+            Pages
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="/patterns/" class="pf-c-nav__link">
+            Patterns
+          </a>
+        </li>
+        <li class="pf-c-nav__item">
+          <a href="/tags/" class="pf-c-nav__link">
+            Tags
+          </a>
+        </li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
Update the demo environment to show various grid layout examples. Includes an example on how to lay out the latest home page design.

Related to Trello card [sandbox-environment-for-modular-column-layouts](https://trello.com/c/yBnfE7s9/701-sandbox-environment-for-modular-column-layouts)

Demo URL: https://rhd-frontend-demo.netlify.com/patterns/layout/grid/

Screenshots:
![image](https://user-images.githubusercontent.com/4032718/67517019-afa2de00-f66f-11e9-9fa0-6debc77a3824.png)
![image](https://user-images.githubusercontent.com/4032718/67517037-b598bf00-f66f-11e9-87b0-269794513c18.png)
![image](https://user-images.githubusercontent.com/4032718/67517052-bd586380-f66f-11e9-81a1-c67ba549893a.png)
![image](https://user-images.githubusercontent.com/4032718/67517070-c5180800-f66f-11e9-9850-eb24365505b2.png)
![image](https://user-images.githubusercontent.com/4032718/67517132-e5e05d80-f66f-11e9-83c9-f00b536d97d0.png)
![image](https://user-images.githubusercontent.com/4032718/67517162-f7296a00-f66f-11e9-8cf6-32ae435c3641.png)
