### PR TITLE
[MWES-3660] Update to support new SSO servers

### DIFF
--- a/src/scripts/js/2018/4-drupal-namespace.js
+++ b/src/scripts/js/2018/4-drupal-namespace.js
@@ -1,3 +1,4 @@
+
 /*
  * Set up namespace and static vars
  */
@@ -149,10 +150,12 @@ app.mktg_ops = {};
 app.ssoConfig = {};
 app.ssoConfig.account_url = drupalSettings.rhd.keycloak.accountUrl;
 app.ssoConfig.auth_url = drupalSettings.rhd.keycloak.authUrl;
+app.ssoConfig.client_id = drupalSettings.rhd.keycloak.client_id;
+app.ssoConfig.realm = drupalSettings.rhd.keycloak.realm;
 
-var homeLink = document.getElementById('home-link') || { href: ''};
-app.ssoConfig.confirmation = homeLink.href + '/confirmation';
-app.ssoConfig.logout_url = homeLink.href;
+var homeLink = 'https://' + drupalSettings.rhd.urls.final_base_url;
+app.ssoConfig.confirmation = homeLink + '/confirmation';
+app.ssoConfig.logout_url = homeLink;
 app.projects = {};
 app.projects.defaultImage = "/images/design/projects/default_200x150.png";
 

--- a/src/scripts/js/rhd/5-sso.js
+++ b/src/scripts/js/rhd/5-sso.js
@@ -158,8 +158,8 @@ app.sso = function () {
 
     var keycloak = Keycloak({
         url: app.ssoConfig.auth_url,
-        realm: 'rhd',
-        clientId: 'web'
+        realm: app.ssoConfig.realm,
+        clientId: app.ssoConfig.client_id
     });
     app.keycloak = keycloak;
 
@@ -178,7 +178,7 @@ app.sso = function () {
         checkIfProtectedPage();
 
         if(app.termsAndConditions) {
-            // app.termsAndConditions.isDownloadPage() test for tcDownloadURL is not empty, tcDownloadFileName is not empty and tcSourceLink (contains 'download-manager') 
+            // app.termsAndConditions.isDownloadPage() test for tcDownloadURL is not empty, tcDownloadFileName is not empty and tcSourceLink (contains 'download-manager')
             if(app.termsAndConditions.isDownloadPage()) {
                 app.termsAndConditions.download();
             }


### PR DESCRIPTION
This commit updates the rhd-frontend component to expose the new SSO configuration variables provided by Drupal and then use those variables in the configuration of the Keycloak initialisation process. This removes the hard-coding of our current SSO server and make it much easier for us to make the transition to the new ones.

