### PR TITLE
[DEVELOPER-408] Updates Foundation column* + column* rule

### DIFF
--- a/src/styles/2018/_legacy.scss
+++ b/src/styles/2018/_legacy.scss
@@ -2029,7 +2029,10 @@ label.inline{
   display: inline-block;
 }
 
-[class*="column"] + [class*="column"]:last-child {
+.column + .column:last-child,
+.column + .columns:last-child,
+.columns + .column:last-child,
+.columns + .columns:last-child {
   float:left;
 }
 


### PR DESCRIPTION
This updates a 3 line rule that was used to target sibling Foundation
column* classes. Due to the wildcard, it was targeting non-Foundation
classes with the string 'column' anywhere in the classname.

Resolves #408 
Unblocks https://github.com/redhat-developer/developers.redhat.com/pull/3310